### PR TITLE
Add the --format option with 'text' and 'ndjson'

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ Now you can also filter time entries by project ID:
     ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                         Total      7:05
 
+Supports NDJSON as alternative output format using the  `--format` option:
+
+    $ tgl --format ndjson entries --project-id 178435728 list
+
+    {"id": 2832493940, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-02-06T10:31:24+00:00", "description": "ESF: send after input has output", "start": "2023-02-06T09:40:10+00:00", "stop": "2023-02-06T10:31:24+00:00", "duration": 3074, "tags": ["type:goal"]}
+    {"id": 2832473617, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-02-06T09:34:53+00:00", "description": "Maurizio / Tom", "start": "2023-02-06T08:58:17+00:00", "stop": "2023-02-06T09:29:22+00:00", "duration": 1865, "tags": ["type:meeting"]}
+    {"id": 2832337954, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-02-06T09:34:39+00:00", "description": "sync", "start": "2023-02-06T08:15:08+00:00", "stop": "2023-02-06T08:57:17+00:00", "duration": 2529, "tags": ["type:sync"]}
+
 For grouping time entries by tags and sum up the totals, run:
 
     $ tgl entries --project-id 178435728 group-by --field tags --start-date 2023-02-01

--- a/tests/cassettes/test_entries_group_by/test_group_by_initiative_as_ndjson.yaml
+++ b/tests/cassettes/test_entries_group_by/test_group_by_initiative_as_ndjson.yaml
@@ -1,0 +1,81 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.2
+    method: GET
+    uri: https://api.track.toggl.com/api/v9/me/time_entries?start_date=2023-01-26T00%3A00%3A00Z&end_date=2023-01-27T00%3A00%3A00Z
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEA9WZ3Y7jNBTHX8XKLR3JH7GT+G6ZYaWVQCDNSkisViNP47bZpklInC2ziDdgJa4R
+        Ele8AE/GI3CSJpO6KZluacIg9aZO1Nrndz7+5/jNj04UOpL6JCCU48CbOds0XxeZmuu76gnxCcfE
+        nzlZnr7Tc7Nb9HyXcY/CslHFul5LyjieOfdRHKv7WDtyoeJCz5zCqNw40qGYsitMrqh4TamkXDL+
+        GcYSY6d6J816r3BXMvYdPA3LXJkoTWAvHoN/DHUxz6Nst+Rcp5tNmUTmQaIXcZxuUabyIkqWKF2g
+        V9+8F0iFYa6LQhcoSuCz1IVBWZTpOEo0/LpRy8KRbxzzkGlZlFmWwnbf1utwrOoRodjzscCwCFtJ
+        k/jBkSYv4Wyqf7B6193BdP5e53ehjrXR4V31/s5MZQHLteEFJYyxmVNa37a26etvrc1/mnXMsE+p
+        oFMwI9LlkpDuaMeY1VhtZtSl7gCzl9EPj8R0nqc5mseRTgARcEBRge5jlayRSkIA+a4Edgt4x0Qb
+        fWvUJrs8wAPPnAKgO0nQ7QDiIYANYxsg+T/Qo1eYvcaedIVkQXfEKeiR6ehhvztaP/wawDY9yA3/
+        mC+fTez9V/QwIxzce/yCh8Erpes9SQ8HNj0W0CGALz6UuUa30TKB0vZVGpaxRqo0K8if0byumXdQ
+        tedQ/aDuQRUyKooL9KooyotXvtr58HSh5/se1L7TQo/62CUBw2eJFeJLHkg+mDcbvDY7HlRiyg6+
+        v37/+Ce6iZJE513lssTGCSKj50wXzHKtqfY0hu8Rl2JQKKOHCfEkYSANB8KkouFLeqALBQ0GdeGz
+        CZN2+90JL8iOHBGIvhA+P1EgtuzPCxMhXQAzFCYtXjtMoLvg/TD59Wd0uyqNAZG+RGvQ4ehem63W
+        CVqlG0hyIAe3K2U0qOuzA6ndzygwWmPuBxIXAvPTUtYjy/NgcMmhwdrLxj21QHa8qA2DEQGBbues
+        /Qbr+QRSs/1R2D0a34LnBtwFTx0/C3JQCpK43dH68Bq+NrwjgXSTpxlaaRXqHMXpElU9b9UGX8dp
+        Gb6EXtYgCKHEFF0QXaQRJj0HHDvPuYJgAhV+CjyYSXeoEYbT1wRtPFSQXmx9EasCpNrXSa3kJPq+
+        hOkEjDoKtMjTDbrRSfQBXafFukwuT+jAy8YmRD3ieZMEEJOYDI+XCMyWQEYJmxBnbr/ZrSIFtDVM
+        mNK8KkZX6Fut1zADqkdE3ehoo7WB5/boKAiYgAL3tKhrN9QF/dg4YJbGPXFSwLS17LxaRAGFZEO9
+        D4g+mAQe0iBuEBzWItDPv6Evy2S+6sz/ifIZ/gzQ8730ekFLt5baLxyE+rwagY2fmajEUBYHJdgO
+        BrH9Hlyh5/fFQzLvbNwUhWrNMnczGiUnOHjzz9M5OPa48CapCJBs4POE3Ws0tt0pqSqWrbaWCtp3
+        GHCm217G/5cZpucdF/T7o4oJw2h6kvsEAvEMgmNoOEZ2jA4cvxq9HwJQlcalEsbM9W1C2RsxL1MV
+        H40CdkIUNNuYLAo8z2e0ur0ZPftg6P5cSQZ7joaTHQUB7uf5i2efnoeM7Pyeh6G+Qv06we4BxzQQ
+        VZN+xl0azLypL929ctbrFoAMfAi2zU6ZgOpvJx+TLpfxlcnVfC2hV4DLluqiBUGDkEd6r0ewasDT
+        Xt9uYBSvb623V3I9GHrgAOw5uvHrLpQP+TzwgTkDPhhYEeH3LsXGMn6zgemMz+Am+bS628ql8zxf
+        VHJnsOxWNbca3x54PnePCMs/fkGf51qtF9CRdcLnUz295xAXzDOttSxPJxga3wk8vbr7He6pwNg1
+        D9vYjAa98d5Ynt5ziAsa/zHNvP0bd0fgfDIhAAA=
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 07 Feb 2023 05:28:38 GMT
+      Instance:
+      - time-public-api
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 google
+      X-Content-Type-Options:
+      - nosniff
+      X-Request-ID:
+      - 8a858670872d34554e1dbf3e81756797
+      X-Service-Level:
+      - GREEN
+      X-Toggl-Request-Id:
+      - 8a858670872d34554e1dbf3e81756797
+      X-We-are-hiring:
+      - https://toggl.com/jobs/
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_entries_list/test_list_as_ndjson.yaml
+++ b/tests/cassettes/test_entries_list/test_list_as_ndjson.yaml
@@ -1,0 +1,81 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.2
+    method: GET
+    uri: https://api.track.toggl.com/api/v9/me/time_entries?start_date=2023-01-26T00%3A00%3A00Z&end_date=2023-01-27T00%3A00%3A00Z
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEA9WZ3Y7jNBTHX8XKLR3JH7GT+G6ZYaWVQCDNSkisViNP47bZpklInC2ziDdgJa4R
+        Ele8AE/GI3CSJpO6KZluacIg9aZO1Nrndz7+5/jNj04UOpL6JCCU48CbOds0XxeZmuu76gnxCcfE
+        nzlZnr7Tc7Nb9HyXcY/CslHFul5LyjieOfdRHKv7WDtyoeJCz5zCqNw40qGYsitMrqh4TamkXDL+
+        GcYSY6d6J816r3BXMvYdPA3LXJkoTWAvHoN/DHUxz6Nst+Rcp5tNmUTmQaIXcZxuUabyIkqWKF2g
+        V9+8F0iFYa6LQhcoSuCz1IVBWZTpOEo0/LpRy8KRbxzzkGlZlFmWwnbf1utwrOoRodjzscCwCFtJ
+        k/jBkSYv4Wyqf7B6193BdP5e53ehjrXR4V31/s5MZQHLteEFJYyxmVNa37a26etvrc1/mnXMsE+p
+        oFMwI9LlkpDuaMeY1VhtZtSl7gCzl9EPj8R0nqc5mseRTgARcEBRge5jlayRSkIA+a4Edgt4x0Qb
+        fWvUJrs8wAPPnAKgO0nQ7QDiIYANYxsg+T/Qo1eYvcaedIVkQXfEKeiR6ehhvztaP/wawDY9yA3/
+        mC+fTez9V/QwIxzce/yCh8Erpes9SQ8HNj0W0CGALz6UuUa30TKB0vZVGpaxRqo0K8if0byumXdQ
+        tedQ/aDuQRUyKooL9KooyotXvtr58HSh5/se1L7TQo/62CUBw2eJFeJLHkg+mDcbvDY7HlRiyg6+
+        v37/+Ce6iZJE513lssTGCSKj50wXzHKtqfY0hu8Rl2JQKKOHCfEkYSANB8KkouFLeqALBQ0GdeGz
+        CZN2+90JL8iOHBGIvhA+P1EgtuzPCxMhXQAzFCYtXjtMoLvg/TD59Wd0uyqNAZG+RGvQ4ehem63W
+        CVqlG0hyIAe3K2U0qOuzA6ndzygwWmPuBxIXAvPTUtYjy/NgcMmhwdrLxj21QHa8qA2DEQGBbues
+        /Qbr+QRSs/1R2D0a34LnBtwFTx0/C3JQCpK43dH68Bq+NrwjgXSTpxlaaRXqHMXpElU9b9UGX8dp
+        Gb6EXtYgCKHEFF0QXaQRJj0HHDvPuYJgAhV+CjyYSXeoEYbT1wRtPFSQXmx9EasCpNrXSa3kJPq+
+        hOkEjDoKtMjTDbrRSfQBXafFukwuT+jAy8YmRD3ieZMEEJOYDI+XCMyWQEYJmxBnbr/ZrSIFtDVM
+        mNK8KkZX6Fut1zADqkdE3ehoo7WB5/boKAiYgAL3tKhrN9QF/dg4YJbGPXFSwLS17LxaRAGFZEO9
+        D4g+mAQe0iBuEBzWItDPv6Evy2S+6sz/ifIZ/gzQ8730ekFLt5baLxyE+rwagY2fmajEUBYHJdgO
+        BrH9Hlyh5/fFQzLvbNwUhWrNMnczGiUnOHjzz9M5OPa48CapCJBs4POE3Ws0tt0pqSqWrbaWCtp3
+        GHCm217G/5cZpucdF/T7o4oJw2h6kvsEAvEMgmNoOEZ2jA4cvxq9HwJQlcalEsbM9W1C2RsxL1MV
+        H40CdkIUNNuYLAo8z2e0ur0ZPftg6P5cSQZ7joaTHQUB7uf5i2efnoeM7Pyeh6G+Qv06we4BxzQQ
+        VZN+xl0azLypL929ctbrFoAMfAi2zU6ZgOpvJx+TLpfxlcnVfC2hV4DLluqiBUGDkEd6r0ewasDT
+        Xt9uYBSvb623V3I9GHrgAOw5uvHrLpQP+TzwgTkDPhhYEeH3LsXGMn6zgemMz+Am+bS628ql8zxf
+        VHJnsOxWNbca3x54PnePCMs/fkGf51qtF9CRdcLnUz295xAXzDOttSxPJxga3wk8vbr7He6pwNg1
+        D9vYjAa98d5Ynt5ziAsa/zHNvP0bd0fgfDIhAAA=
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 07 Feb 2023 05:26:12 GMT
+      Instance:
+      - time-public-api
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 google
+      X-Content-Type-Options:
+      - nosniff
+      X-Request-ID:
+      - dd0d87870fbc46bc714cffb130004d03
+      X-Service-Level:
+      - GREEN
+      X-Toggl-Request-Id:
+      - dd0d87870fbc46bc714cffb130004d03
+      X-We-are-hiring:
+      - https://toggl.com/jobs/
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_entries_group_by.py
+++ b/tests/test_entries_group_by.py
@@ -101,3 +101,28 @@ def test_group_by_initiative(save_to_tmp):
 
 """
         )
+
+
+@pytest.mark.vcr
+@pytest.mark.block_network
+def test_group_by_initiative_as_ndjson(save_to_tmp):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            ["--format", "ndjson", "entries", "--project-id", "178435728", "group-by", "--field", "initiative", "--start-date", "2023-01-26", "--end-date", "2023-01-27"],
+            env=env,
+        )
+        save_to_tmp(result.output, name="test_group_by_initiative_as_ndjson")
+        assert result.exit_code == 0
+        assert (
+            result.output
+            == """{"field": "initiative", "name": "Community", "duration": 17548}
+{"field": "initiative", "name": "sync", "duration": 10830}
+{"field": "initiative", "name": "Cloud Monitoring - Weekly", "duration": 5341}
+{"field": "initiative", "name": "ElasticOnAzure", "duration": 2613}
+{"field": "initiative", "name": "azure2", "duration": 2133}
+{"field": "initiative", "name": "gather town", "duration": 2110}
+{"field": "initiative", "name": "Drop header log line in CloudFront events", "duration": 505}
+"""
+        )

--- a/tests/test_entries_list.py
+++ b/tests/test_entries_list.py
@@ -174,3 +174,35 @@ def test_list_with_a_running_time_entry(save_to_tmp):
 """
         )
         
+
+@pytest.mark.vcr
+@pytest.mark.block_network
+def test_list_as_ndjson(save_to_tmp):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            ["--format", "ndjson", "entries", "--project-id", "178435728", "list", "--start-date", "2023-01-26", "--end-date", "2023-01-27"],
+            env=env,
+        )
+        save_to_tmp(result.output, name="test_list_as_ndjson")
+        assert result.exit_code == 0
+        assert (
+            result.output
+            == """{"id": 2819125097, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T22:54:33+00:00", "description": "Community: Allow parsing of IPv6 addresses in ingest pipeline", "start": "2023-01-26T22:25:35+00:00", "stop": "2023-01-26T22:54:33+00:00", "duration": 1738, "tags": ["type:support"]}
+{"id": 2819082262, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T22:25:35+00:00", "description": "Community: Fix parsing error client port is blank and adjust for timeStamp", "start": "2023-01-26T21:45:11+00:00", "stop": "2023-01-26T22:25:35+00:00", "duration": 2424, "tags": ["type:support"]}
+{"id": 2819082247, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-02-03T07:46:39+00:00", "description": "Community: Fix parsing error client port is blank and adjust for timeStamp", "start": "2023-01-26T21:45:10+00:00", "stop": "2023-01-26T21:45:11+00:00", "duration": 1, "tags": ["type:support"]}
+{"id": 2819082217, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-02-03T07:46:39+00:00", "description": "Community: Fix parsing error client port is blank and adjust for timeStamp", "start": "2023-01-26T21:45:08+00:00", "stop": "2023-01-26T21:45:10+00:00", "duration": 2, "tags": ["type:support"]}
+{"id": 2819003151, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T21:45:09+00:00", "description": "Community: Azure Signin Module authentication_processing_details Issue", "start": "2023-01-26T20:39:47+00:00", "stop": "2023-01-26T21:45:09+00:00", "duration": 3922, "tags": ["type:support"]}
+{"id": 2818714203, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T18:58:23+00:00", "description": "Community: Azure Signin Module authentication_processing_details Issue", "start": "2023-01-26T17:13:25+00:00", "stop": "2023-01-26T18:58:23+00:00", "duration": 6298, "tags": ["type:support"]}
+{"id": 2818566057, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T16:48:22+00:00", "description": "Community: Azure Signin Module authentication_processing_details Issue", "start": "2023-01-26T15:55:39+00:00", "stop": "2023-01-26T16:48:22+00:00", "duration": 3163, "tags": ["type:support"]}
+{"id": 2818549545, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T15:55:39+00:00", "description": "Drop header log line in CloudFront events", "start": "2023-01-26T15:47:14+00:00", "stop": "2023-01-26T15:55:39+00:00", "duration": 505, "tags": ["type:support"]}
+{"id": 2818461010, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T15:47:14+00:00", "description": "ElasticOnAzure: questions from Deniz Coskun", "start": "2023-01-26T15:03:41+00:00", "stop": "2023-01-26T15:47:14+00:00", "duration": 2613, "tags": ["type:support"]}
+{"id": 2818271775, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T14:30:36+00:00", "description": "Cloud Monitoring - Weekly", "start": "2023-01-26T13:01:35+00:00", "stop": "2023-01-26T14:30:36+00:00", "duration": 5341, "tags": ["type:meeting"]}
+{"id": 2818128524, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T12:35:31+00:00", "description": "sync", "start": "2023-01-26T12:06:40+00:00", "stop": "2023-01-26T12:35:31+00:00", "duration": 1731, "tags": ["type:sync"]}
+{"id": 2818075670, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T12:06:40+00:00", "description": "gather town", "start": "2023-01-26T11:31:30+00:00", "stop": "2023-01-26T12:06:40+00:00", "duration": 2110, "tags": ["type:meeting"]}
+{"id": 2818022697, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T11:31:31+00:00", "description": "azure2: follow up", "start": "2023-01-26T10:55:58+00:00", "stop": "2023-01-26T11:31:31+00:00", "duration": 2133, "tags": ["type:goal"]}
+{"id": 2817783218, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T10:55:58+00:00", "description": "sync", "start": "2023-01-26T08:24:19+00:00", "stop": "2023-01-26T10:55:58+00:00", "duration": 9099, "tags": ["type:sync"]}
+"""
+        )
+        

--- a/toggl_track/result.py
+++ b/toggl_track/result.py
@@ -1,4 +1,5 @@
 import io
+import json
 import datetime as dt
 from itertools import groupby
 from typing import Any, List
@@ -71,7 +72,7 @@ class GroupByCriterion(object):
         return v
 
 class TimeEntriesGroupByResult(object):
-    """MISSING DOCSTRING"""
+    """Turns a list of TimeEntry objects into a rich table grouped by a criterion."""
 
     def __init__(self, entries: List[TimeEntry], key_func: GroupByCriterion) -> None:
         self.key_func = key_func
@@ -120,6 +121,17 @@ class TimeEntriesGroupByResult(object):
         console.print(table)
 
         return console.file.getvalue()
+
+    def ndjson(self) -> str:
+        """Returns a newline-delimited JSON string."""
+        return "\n".join([json.dumps({"field": self.key_func.name, "name": k, "duration": v}) for k, v in self.entries])
+
+
+def render(result: Any, format: str = "text") -> str:
+    """Renders a result object as a string."""
+    if format == "ndjson":
+        return result.ndjson()
+    return str(result)
 
 
 def format_duration(duration: int) -> str:


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

The CLI now offers a new `--format` option that supports the following formats:

- `text`
- `ndjson`

The `text` format renders the result using tables. This is the default format.

The `ndjson` format renders the result as JSON objects separated by a "\n". This is useful for using the data with other tools.

### Change description
<!-- What does your code do? -->

The `Result` classes now must support a `ndjson()` method alongside the current `str()` method. The `ndjson()` method must return an NDJSON representation of the data.

We added a new `result.render()` function for the `cli` module. This the function will take care of calling the proper method on the `Result` object, according to the `format` argument.


### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
* [x] Changes are covered by tests.
* [x] Logging is meaningful in case of troubleshooting.
* [x] Docs are updated (at least the `README.md`, if needed).
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.