### PR TITLE
Fix failing tests on Python3.10+ by rewriting vcrpy casettes 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: [push, pull_request]
+on: [push]
 
 permissions:
   contents: read

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     """,
     install_requires=[
         "click",
-        "pydantic",
+        "pydantic < 2,
         "requests",
         "rich",
         ],

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     """,
     install_requires=[
         "click",
-        "pydantic < 2,
+        "pydantic < 2",
         "requests",
         "rich",
         ],

--- a/setup.py
+++ b/setup.py
@@ -32,15 +32,15 @@ setup(
         tgl=toggl_track.cli:cli
     """,
     install_requires=[
-        "click",
+        "click == 8.1.7",
         "pydantic < 2",
-        "requests",
-        "rich",
+        "requests == 2.31.0",
+        "rich == 13.7.1",
         ],
     extras_require={
         "test": [
-            "pytest",
-            "pytest-recording",
+            "pytest == 8.1.1",
+            "pytest-recording == 0.13.1",
             ]
     },
     python_requires=">=3.7",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         ],
     extras_require={
         "test": [
-            "pytest == 8.1.1",
+            "pytest == 7.4.4",
             "pytest-recording == 0.13.1",
             ]
     },

--- a/tests/cassettes/test_entries_group_by/test_group_by_initiative.yaml
+++ b/tests/cassettes/test_entries_group_by/test_group_by_initiative.yaml
@@ -9,70 +9,49 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.28.2
+      - python-requests/2.31.0
     method: GET
-    uri: https://api.track.toggl.com/api/v9/me/time_entries?start_date=2023-01-26T00%3A00%3A00Z&end_date=2023-01-27T00%3A00%3A00Z
+    uri: https://api.track.toggl.com/api/v9/me/time_entries?start_date=2024-01-26T00%3A00%3A00Z&end_date=2024-01-27T00%3A00%3A00Z
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAEA9WZ3Y7jNBTHX8XKLR3JH7GT+G6ZYaWVQCDNSkisViNP47bZpklInC2ziDdgJa4R
-        Ele8AE/GI3CSJpO6KZluacIg9aZO1Nrndz7+5/jNj04UOpL6JCCU48CbOds0XxeZmuu76gnxCcfE
-        nzlZnr7Tc7Nb9HyXcY/CslHFul5LyjieOfdRHKv7WDtyoeJCz5zCqNw40qGYsitMrqh4TamkXDL+
-        GcYSY6d6J816r3BXMvYdPA3LXJkoTWAvHoN/DHUxz6Nst+Rcp5tNmUTmQaIXcZxuUabyIkqWKF2g
-        V9+8F0iFYa6LQhcoSuCz1IVBWZTpOEo0/LpRy8KRbxzzkGlZlFmWwnbf1utwrOoRodjzscCwCFtJ
-        k/jBkSYv4Wyqf7B6193BdP5e53ehjrXR4V31/s5MZQHLteEFJYyxmVNa37a26etvrc1/mnXMsE+p
-        oFMwI9LlkpDuaMeY1VhtZtSl7gCzl9EPj8R0nqc5mseRTgARcEBRge5jlayRSkIA+a4Edgt4x0Qb
-        fWvUJrs8wAPPnAKgO0nQ7QDiIYANYxsg+T/Qo1eYvcaedIVkQXfEKeiR6ehhvztaP/wawDY9yA3/
-        mC+fTez9V/QwIxzce/yCh8Erpes9SQ8HNj0W0CGALz6UuUa30TKB0vZVGpaxRqo0K8if0byumXdQ
-        tedQ/aDuQRUyKooL9KooyotXvtr58HSh5/se1L7TQo/62CUBw2eJFeJLHkg+mDcbvDY7HlRiyg6+
-        v37/+Ce6iZJE513lssTGCSKj50wXzHKtqfY0hu8Rl2JQKKOHCfEkYSANB8KkouFLeqALBQ0GdeGz
-        CZN2+90JL8iOHBGIvhA+P1EgtuzPCxMhXQAzFCYtXjtMoLvg/TD59Wd0uyqNAZG+RGvQ4ehem63W
-        CVqlG0hyIAe3K2U0qOuzA6ndzygwWmPuBxIXAvPTUtYjy/NgcMmhwdrLxj21QHa8qA2DEQGBbues
-        /Qbr+QRSs/1R2D0a34LnBtwFTx0/C3JQCpK43dH68Bq+NrwjgXSTpxlaaRXqHMXpElU9b9UGX8dp
-        Gb6EXtYgCKHEFF0QXaQRJj0HHDvPuYJgAhV+CjyYSXeoEYbT1wRtPFSQXmx9EasCpNrXSa3kJPq+
-        hOkEjDoKtMjTDbrRSfQBXafFukwuT+jAy8YmRD3ieZMEEJOYDI+XCMyWQEYJmxBnbr/ZrSIFtDVM
-        mNK8KkZX6Fut1zADqkdE3ehoo7WB5/boKAiYgAL3tKhrN9QF/dg4YJbGPXFSwLS17LxaRAGFZEO9
-        D4g+mAQe0iBuEBzWItDPv6Evy2S+6sz/ifIZ/gzQ8730ekFLt5baLxyE+rwagY2fmajEUBYHJdgO
-        BrH9Hlyh5/fFQzLvbNwUhWrNMnczGiUnOHjzz9M5OPa48CapCJBs4POE3Ws0tt0pqSqWrbaWCtp3
-        GHCm217G/5cZpucdF/T7o4oJw2h6kvsEAvEMgmNoOEZ2jA4cvxq9HwJQlcalEsbM9W1C2RsxL1MV
-        H40CdkIUNNuYLAo8z2e0ur0ZPftg6P5cSQZ7joaTHQUB7uf5i2efnoeM7Pyeh6G+Qv06we4BxzQQ
-        VZN+xl0azLypL929ctbrFoAMfAi2zU6ZgOpvJx+TLpfxlcnVfC2hV4DLluqiBUGDkEd6r0ewasDT
-        Xt9uYBSvb623V3I9GHrgAOw5uvHrLpQP+TzwgTkDPhhYEeH3LsXGMn6zgemMz+Am+bS628ql8zxf
-        VHJnsOxWNbca3x54PnePCMs/fkGf51qtF9CRdcLnUz295xAXzDOttSxPJxga3wk8vbr7He6pwNg1
-        D9vYjAa98d5Ynt5ziAsa/zHNvP0bd0fgfDIhAAA=
+      string: "[{\"id\":3297435983,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T17:26:31+00:00\",\"stop\":\"2024-01-26T18:00:35+00:00\",\"duration\":2044,\"description\":\"IHAC
+        using AWS WAF integration and expresses concern about the throughput\",\"tags\":[\"type:support/question\"],\"tag_ids\":[14969753],\"duronly\":true,\"at\":\"2024-01-28T08:39:01+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3297355840,\"workspace_id\":1815018,\"project_id\":28041930,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T16:34:40+00:00\",\"stop\":\"2024-01-26T17:26:32+00:00\",\"duration\":3112,\"description\":\"\U0001F68C
+        Shuttling kids between home and whatever\",\"tags\":[],\"tag_ids\":[],\"duronly\":true,\"at\":\"2024-01-26T17:26:32+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":28041930,\"permissions\":null},{\"id\":3297169916,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T14:48:28+00:00\",\"stop\":\"2024-01-26T16:34:41+00:00\",\"duration\":6373,\"description\":\"S3
+        SQS ingest delay in performance with Elastic Agent #4264\",\"tags\":[\"type:support/sdh\"],\"tag_ids\":[15007828],\"duronly\":true,\"at\":\"2024-01-26T16:34:41+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3297063846,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T13:50:21+00:00\",\"stop\":\"2024-01-26T14:48:28+00:00\",\"duration\":3487,\"description\":\"Migrate
+        to ecs@mappings template shipped with Elasticsearch [step 3]\",\"tags\":[\"type:goal\"],\"tag_ids\":[12078063],\"duronly\":true,\"at\":\"2024-01-26T14:48:28+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3297055770,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T13:45:19+00:00\",\"stop\":\"2024-01-26T13:50:21+00:00\",\"duration\":302,\"description\":\"sync\",\"tags\":[\"type:sync\"],\"tag_ids\":[12078061],\"duronly\":true,\"at\":\"2024-01-26T13:50:21+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3296925719,\"workspace_id\":1815018,\"project_id\":28041930,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T12:20:36+00:00\",\"stop\":\"2024-01-26T13:45:19+00:00\",\"duration\":5083,\"description\":\"\U0001F35C
+        Lunch\",\"tags\":[],\"tag_ids\":[],\"duronly\":true,\"at\":\"2024-01-26T13:45:19+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":28041930,\"permissions\":null},{\"id\":3296620722,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T08:44:02+00:00\",\"stop\":\"2024-01-26T12:20:37+00:00\",\"duration\":12995,\"description\":\"Migrate
+        to ecs@mappings template shipped with Elasticsearch [step 3]\",\"tags\":[\"type:goal\"],\"tag_ids\":[12078063],\"duronly\":true,\"at\":\"2024-01-26T12:20:37+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3296545927,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T07:48:47+00:00\",\"stop\":\"2024-01-26T08:44:02+00:00\",\"duration\":3315,\"description\":\"sync\",\"tags\":[\"type:sync\"],\"tag_ids\":[12078061],\"duronly\":true,\"at\":\"2024-01-26T08:44:02+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null}]"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Cache-Control:
       - no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0
-      Content-Encoding:
-      - gzip
+      Content-Length:
+      - '3477'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 06 Feb 2023 04:51:02 GMT
+      - Fri, 26 Apr 2024 04:59:26 GMT
       Instance:
-      - time-public-api
+      - track-public-api-proxy-f666f86df-kw6z2
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=15552000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
       Via:
       - 1.1 google
       X-Content-Type-Options:
       - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
       X-Request-ID:
-      - bc548dc060c4f515eb43a2fe1591c8a7
+      - 347b30cd322573b65a1f7f194b69867b
       X-Service-Level:
       - GREEN
       X-Toggl-Request-Id:
-      - bc548dc060c4f515eb43a2fe1591c8a7
+      - 99c18309-93a8-498b-9339-7e8408412d02
       X-We-are-hiring:
       - https://toggl.com/jobs/
     status:

--- a/tests/cassettes/test_entries_group_by/test_group_by_initiative_as_json_with_root_element.yaml
+++ b/tests/cassettes/test_entries_group_by/test_group_by_initiative_as_json_with_root_element.yaml
@@ -9,70 +9,49 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.28.2
+      - python-requests/2.31.0
     method: GET
-    uri: https://api.track.toggl.com/api/v9/me/time_entries?start_date=2023-01-26T00%3A00%3A00Z&end_date=2023-01-27T00%3A00%3A00Z
+    uri: https://api.track.toggl.com/api/v9/me/time_entries?start_date=2024-01-26T00%3A00%3A00Z&end_date=2024-01-27T00%3A00%3A00Z
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAEA9WZ3Y7jNBTHX8XKLR3JH7GT+G6ZYaWVQCDNSkisViNP47bZpklInC2ziDdgJa4R
-        Ele8AE/GI3CSJpO6KZluacIg9aZO1Nrndz7+5/jNj04UOpL6JCCU48CbOds0XxeZmuu76gnxCcfE
-        nzlZnr7Tc7Nb9HyXcY/CslHFul5LyjieOfdRHKv7WDtyoeJCz5zCqNw40qGYsitMrqh4TamkXDL+
-        GcYSY6d6J816r3BXMvYdPA3LXJkoTWAvHoN/DHUxz6Nst+Rcp5tNmUTmQaIXcZxuUabyIkqWKF2g
-        V9+8F0iFYa6LQhcoSuCz1IVBWZTpOEo0/LpRy8KRbxzzkGlZlFmWwnbf1utwrOoRodjzscCwCFtJ
-        k/jBkSYv4Wyqf7B6193BdP5e53ehjrXR4V31/s5MZQHLteEFJYyxmVNa37a26etvrc1/mnXMsE+p
-        oFMwI9LlkpDuaMeY1VhtZtSl7gCzl9EPj8R0nqc5mseRTgARcEBRge5jlayRSkIA+a4Edgt4x0Qb
-        fWvUJrs8wAPPnAKgO0nQ7QDiIYANYxsg+T/Qo1eYvcaedIVkQXfEKeiR6ehhvztaP/wawDY9yA3/
-        mC+fTez9V/QwIxzce/yCh8Erpes9SQ8HNj0W0CGALz6UuUa30TKB0vZVGpaxRqo0K8if0byumXdQ
-        tedQ/aDuQRUyKooL9KooyotXvtr58HSh5/se1L7TQo/62CUBw2eJFeJLHkg+mDcbvDY7HlRiyg6+
-        v37/+Ce6iZJE513lssTGCSKj50wXzHKtqfY0hu8Rl2JQKKOHCfEkYSANB8KkouFLeqALBQ0GdeGz
-        CZN2+90JL8iOHBGIvhA+P1EgtuzPCxMhXQAzFCYtXjtMoLvg/TD59Wd0uyqNAZG+RGvQ4ehem63W
-        CVqlG0hyIAe3K2U0qOuzA6ndzygwWmPuBxIXAvPTUtYjy/NgcMmhwdrLxj21QHa8qA2DEQGBbues
-        /Qbr+QRSs/1R2D0a34LnBtwFTx0/C3JQCpK43dH68Bq+NrwjgXSTpxlaaRXqHMXpElU9b9UGX8dp
-        Gb6EXtYgCKHEFF0QXaQRJj0HHDvPuYJgAhV+CjyYSXeoEYbT1wRtPFSQXmx9EasCpNrXSa3kJPq+
-        hOkEjDoKtMjTDbrRSfQBXafFukwuT+jAy8YmRD3ieZMEEJOYDI+XCMyWQEYJmxBnbr/ZrSIFtDVM
-        mNK8KkZX6Fut1zADqkdE3ehoo7WB5/boKAiYgAL3tKhrN9QF/dg4YJbGPXFSwLS17LxaRAGFZEO9
-        D4g+mAQe0iBuEBzWItDPv6Evy2S+6sz/ifIZ/gzQ8730ekFLt5baLxyE+rwagY2fmajEUBYHJdgO
-        BrH9Hlyh5/fFQzLvbNwUhWrNMnczGiUnOHjzz9M5OPa48CapCJBs4POE3Ws0tt0pqSqWrbaWCtp3
-        GHCm217G/5cZpucdF/T7o4oJw2h6kvsEAvEMgmNoOEZ2jA4cvxq9HwJQlcalEsbM9W1C2RsxL1MV
-        H40CdkIUNNuYLAo8z2e0ur0ZPftg6P5cSQZ7joaTHQUB7uf5i2efnoeM7Pyeh6G+Qv06we4BxzQQ
-        VZN+xl0azLypL929ctbrFoAMfAi2zU6ZgOpvJx+TLpfxlcnVfC2hV4DLluqiBUGDkEd6r0ewasDT
-        Xt9uYBSvb623V3I9GHrgAOw5uvHrLpQP+TzwgTkDPhhYEeH3LsXGMn6zgemMz+Am+bS628ql8zxf
-        VHJnsOxWNbca3x54PnePCMs/fkGf51qtF9CRdcLnUz295xAXzDOttSxPJxga3wk8vbr7He6pwNg1
-        D9vYjAa98d5Ynt5ziAsa/zHNvP0bd0fgfDIhAAA=
+      string: "[{\"id\":3297435983,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T17:26:31+00:00\",\"stop\":\"2024-01-26T18:00:35+00:00\",\"duration\":2044,\"description\":\"IHAC
+        using AWS WAF integration and expresses concern about the throughput\",\"tags\":[\"type:support/question\"],\"tag_ids\":[14969753],\"duronly\":true,\"at\":\"2024-01-28T08:39:01+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3297355840,\"workspace_id\":1815018,\"project_id\":28041930,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T16:34:40+00:00\",\"stop\":\"2024-01-26T17:26:32+00:00\",\"duration\":3112,\"description\":\"\U0001F68C
+        Shuttling kids between home and whatever\",\"tags\":[],\"tag_ids\":[],\"duronly\":true,\"at\":\"2024-01-26T17:26:32+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":28041930,\"permissions\":null},{\"id\":3297169916,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T14:48:28+00:00\",\"stop\":\"2024-01-26T16:34:41+00:00\",\"duration\":6373,\"description\":\"S3
+        SQS ingest delay in performance with Elastic Agent #4264\",\"tags\":[\"type:support/sdh\"],\"tag_ids\":[15007828],\"duronly\":true,\"at\":\"2024-01-26T16:34:41+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3297063846,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T13:50:21+00:00\",\"stop\":\"2024-01-26T14:48:28+00:00\",\"duration\":3487,\"description\":\"Migrate
+        to ecs@mappings template shipped with Elasticsearch [step 3]\",\"tags\":[\"type:goal\"],\"tag_ids\":[12078063],\"duronly\":true,\"at\":\"2024-01-26T14:48:28+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3297055770,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T13:45:19+00:00\",\"stop\":\"2024-01-26T13:50:21+00:00\",\"duration\":302,\"description\":\"sync\",\"tags\":[\"type:sync\"],\"tag_ids\":[12078061],\"duronly\":true,\"at\":\"2024-01-26T13:50:21+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3296925719,\"workspace_id\":1815018,\"project_id\":28041930,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T12:20:36+00:00\",\"stop\":\"2024-01-26T13:45:19+00:00\",\"duration\":5083,\"description\":\"\U0001F35C
+        Lunch\",\"tags\":[],\"tag_ids\":[],\"duronly\":true,\"at\":\"2024-01-26T13:45:19+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":28041930,\"permissions\":null},{\"id\":3296620722,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T08:44:02+00:00\",\"stop\":\"2024-01-26T12:20:37+00:00\",\"duration\":12995,\"description\":\"Migrate
+        to ecs@mappings template shipped with Elasticsearch [step 3]\",\"tags\":[\"type:goal\"],\"tag_ids\":[12078063],\"duronly\":true,\"at\":\"2024-01-26T12:20:37+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3296545927,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T07:48:47+00:00\",\"stop\":\"2024-01-26T08:44:02+00:00\",\"duration\":3315,\"description\":\"sync\",\"tags\":[\"type:sync\"],\"tag_ids\":[12078061],\"duronly\":true,\"at\":\"2024-01-26T08:44:02+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null}]"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Cache-Control:
       - no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0
-      Content-Encoding:
-      - gzip
+      Content-Length:
+      - '3477'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Feb 2023 05:34:18 GMT
+      - Fri, 26 Apr 2024 04:59:26 GMT
       Instance:
-      - time-public-api
+      - track-public-api-proxy-f666f86df-kw6z2
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=15552000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
       Via:
       - 1.1 google
       X-Content-Type-Options:
       - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
       X-Request-ID:
-      - 1905fe2a68d1344282b34731513e9084
+      - ea580eb96a5fab5db3584b6aa62e036b
       X-Service-Level:
       - GREEN
       X-Toggl-Request-Id:
-      - 1905fe2a68d1344282b34731513e9084
+      - 68a21ff2-c386-482f-9ecc-110a27d4cbc9
       X-We-are-hiring:
       - https://toggl.com/jobs/
     status:

--- a/tests/cassettes/test_entries_group_by/test_group_by_initiative_as_ndjson.yaml
+++ b/tests/cassettes/test_entries_group_by/test_group_by_initiative_as_ndjson.yaml
@@ -9,70 +9,49 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.28.2
+      - python-requests/2.31.0
     method: GET
-    uri: https://api.track.toggl.com/api/v9/me/time_entries?start_date=2023-01-26T00%3A00%3A00Z&end_date=2023-01-27T00%3A00%3A00Z
+    uri: https://api.track.toggl.com/api/v9/me/time_entries?start_date=2024-01-27T00%3A00%3A00Z&end_date=2024-01-29T00%3A00%3A00Z
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAEA9WZ3Y7jNBTHX8XKLR3JH7GT+G6ZYaWVQCDNSkisViNP47bZpklInC2ziDdgJa4R
-        Ele8AE/GI3CSJpO6KZluacIg9aZO1Nrndz7+5/jNj04UOpL6JCCU48CbOds0XxeZmuu76gnxCcfE
-        nzlZnr7Tc7Nb9HyXcY/CslHFul5LyjieOfdRHKv7WDtyoeJCz5zCqNw40qGYsitMrqh4TamkXDL+
-        GcYSY6d6J816r3BXMvYdPA3LXJkoTWAvHoN/DHUxz6Nst+Rcp5tNmUTmQaIXcZxuUabyIkqWKF2g
-        V9+8F0iFYa6LQhcoSuCz1IVBWZTpOEo0/LpRy8KRbxzzkGlZlFmWwnbf1utwrOoRodjzscCwCFtJ
-        k/jBkSYv4Wyqf7B6193BdP5e53ehjrXR4V31/s5MZQHLteEFJYyxmVNa37a26etvrc1/mnXMsE+p
-        oFMwI9LlkpDuaMeY1VhtZtSl7gCzl9EPj8R0nqc5mseRTgARcEBRge5jlayRSkIA+a4Edgt4x0Qb
-        fWvUJrs8wAPPnAKgO0nQ7QDiIYANYxsg+T/Qo1eYvcaedIVkQXfEKeiR6ehhvztaP/wawDY9yA3/
-        mC+fTez9V/QwIxzce/yCh8Erpes9SQ8HNj0W0CGALz6UuUa30TKB0vZVGpaxRqo0K8if0byumXdQ
-        tedQ/aDuQRUyKooL9KooyotXvtr58HSh5/se1L7TQo/62CUBw2eJFeJLHkg+mDcbvDY7HlRiyg6+
-        v37/+Ce6iZJE513lssTGCSKj50wXzHKtqfY0hu8Rl2JQKKOHCfEkYSANB8KkouFLeqALBQ0GdeGz
-        CZN2+90JL8iOHBGIvhA+P1EgtuzPCxMhXQAzFCYtXjtMoLvg/TD59Wd0uyqNAZG+RGvQ4ehem63W
-        CVqlG0hyIAe3K2U0qOuzA6ndzygwWmPuBxIXAvPTUtYjy/NgcMmhwdrLxj21QHa8qA2DEQGBbues
-        /Qbr+QRSs/1R2D0a34LnBtwFTx0/C3JQCpK43dH68Bq+NrwjgXSTpxlaaRXqHMXpElU9b9UGX8dp
-        Gb6EXtYgCKHEFF0QXaQRJj0HHDvPuYJgAhV+CjyYSXeoEYbT1wRtPFSQXmx9EasCpNrXSa3kJPq+
-        hOkEjDoKtMjTDbrRSfQBXafFukwuT+jAy8YmRD3ieZMEEJOYDI+XCMyWQEYJmxBnbr/ZrSIFtDVM
-        mNK8KkZX6Fut1zADqkdE3ehoo7WB5/boKAiYgAL3tKhrN9QF/dg4YJbGPXFSwLS17LxaRAGFZEO9
-        D4g+mAQe0iBuEBzWItDPv6Evy2S+6sz/ifIZ/gzQ8730ekFLt5baLxyE+rwagY2fmajEUBYHJdgO
-        BrH9Hlyh5/fFQzLvbNwUhWrNMnczGiUnOHjzz9M5OPa48CapCJBs4POE3Ws0tt0pqSqWrbaWCtp3
-        GHCm217G/5cZpucdF/T7o4oJw2h6kvsEAvEMgmNoOEZ2jA4cvxq9HwJQlcalEsbM9W1C2RsxL1MV
-        H40CdkIUNNuYLAo8z2e0ur0ZPftg6P5cSQZ7joaTHQUB7uf5i2efnoeM7Pyeh6G+Qv06we4BxzQQ
-        VZN+xl0azLypL929ctbrFoAMfAi2zU6ZgOpvJx+TLpfxlcnVfC2hV4DLluqiBUGDkEd6r0ewasDT
-        Xt9uYBSvb623V3I9GHrgAOw5uvHrLpQP+TzwgTkDPhhYEeH3LsXGMn6zgemMz+Am+bS628ql8zxf
-        VHJnsOxWNbca3x54PnePCMs/fkGf51qtF9CRdcLnUz295xAXzDOttSxPJxga3wk8vbr7He6pwNg1
-        D9vYjAa98d5Ynt5ziAsa/zHNvP0bd0fgfDIhAAA=
+      string: "[{\"id\":3298594858,\"workspace_id\":1815018,\"project_id\":95029662,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-28T21:59:26+00:00\",\"stop\":\"2024-01-29T00:26:53+00:00\",\"duration\":8847,\"description\":\"SDH
+        (cli tool)\",\"tags\":[],\"tag_ids\":[],\"duronly\":true,\"at\":\"2024-01-29T00:26:53+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":95029662,\"permissions\":null},{\"id\":3298443610,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-28T15:28:53+00:00\",\"stop\":\"2024-01-28T17:40:57+00:00\",\"duration\":7924,\"description\":\"synthetics
+        kt session #2\",\"tags\":[\"type:goal\"],\"tag_ids\":[12078063],\"duronly\":true,\"at\":\"2024-01-28T17:53:27+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3298369493,\"workspace_id\":1815018,\"project_id\":28041930,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-28T11:42:25+00:00\",\"stop\":\"2024-01-28T15:28:53+00:00\",\"duration\":13588,\"description\":\"\U0001F35C
+        Lunch\",\"tags\":[],\"tag_ids\":[],\"duronly\":true,\"at\":\"2024-01-28T15:28:53+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":28041930,\"permissions\":null},{\"id\":3298348110,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-28T11:04:49+00:00\",\"stop\":\"2024-01-28T11:42:26+00:00\",\"duration\":2257,\"description\":\"synthetics
+        kt session #2\",\"tags\":[\"type:goal\"],\"tag_ids\":[12078063],\"duronly\":true,\"at\":\"2024-01-28T17:53:27+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3298308962,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-28T09:13:30+00:00\",\"stop\":\"2024-01-28T10:58:42+00:00\",\"duration\":6312,\"description\":\"synthetics
+        kt session #2\",\"tags\":[\"type:goal\"],\"tag_ids\":[12078063],\"duronly\":true,\"at\":\"2024-01-28T17:53:27+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3298301704,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-28T08:45:02+00:00\",\"stop\":\"2024-01-28T09:08:57+00:00\",\"duration\":1435,\"description\":\"synthetics
+        kt session #2\",\"tags\":[\"type:goal\"],\"tag_ids\":[12078063],\"duronly\":true,\"at\":\"2024-01-28T17:53:27+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null}]"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Cache-Control:
       - no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0
-      Content-Encoding:
-      - gzip
+      Content-Length:
+      - '2456'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 07 Feb 2023 05:28:38 GMT
+      - Fri, 26 Apr 2024 04:59:26 GMT
       Instance:
-      - time-public-api
+      - track-public-api-proxy-f666f86df-kw6z2
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=15552000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
       Via:
       - 1.1 google
       X-Content-Type-Options:
       - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
       X-Request-ID:
-      - 8a858670872d34554e1dbf3e81756797
+      - c48234c63988680ad776cb4db0cd3c53
       X-Service-Level:
       - GREEN
       X-Toggl-Request-Id:
-      - 8a858670872d34554e1dbf3e81756797
+      - 6ee2397c-4719-4808-a49d-132988d7bfc7
       X-We-are-hiring:
       - https://toggl.com/jobs/
     status:

--- a/tests/cassettes/test_entries_group_by/test_group_by_tags.yaml
+++ b/tests/cassettes/test_entries_group_by/test_group_by_tags.yaml
@@ -9,70 +9,49 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.28.2
+      - python-requests/2.31.0
     method: GET
-    uri: https://api.track.toggl.com/api/v9/me/time_entries?start_date=2023-01-26T00%3A00%3A00Z&end_date=2023-01-27T00%3A00%3A00Z
+    uri: https://api.track.toggl.com/api/v9/me/time_entries?start_date=2024-01-26T00%3A00%3A00Z&end_date=2024-01-27T00%3A00%3A00Z
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAEA9WZ3Y7jNBTHX8XKLR3JH7GT+G6ZYaWVQCDNSkisViNP47bZpklInC2ziDdgJa4R
-        Ele8AE/GI3CSJpO6KZluacIg9aZO1Nrndz7+5/jNj04UOpL6JCCU48CbOds0XxeZmuu76gnxCcfE
-        nzlZnr7Tc7Nb9HyXcY/CslHFul5LyjieOfdRHKv7WDtyoeJCz5zCqNw40qGYsitMrqh4TamkXDL+
-        GcYSY6d6J816r3BXMvYdPA3LXJkoTWAvHoN/DHUxz6Nst+Rcp5tNmUTmQaIXcZxuUabyIkqWKF2g
-        V9+8F0iFYa6LQhcoSuCz1IVBWZTpOEo0/LpRy8KRbxzzkGlZlFmWwnbf1utwrOoRodjzscCwCFtJ
-        k/jBkSYv4Wyqf7B6193BdP5e53ehjrXR4V31/s5MZQHLteEFJYyxmVNa37a26etvrc1/mnXMsE+p
-        oFMwI9LlkpDuaMeY1VhtZtSl7gCzl9EPj8R0nqc5mseRTgARcEBRge5jlayRSkIA+a4Edgt4x0Qb
-        fWvUJrs8wAPPnAKgO0nQ7QDiIYANYxsg+T/Qo1eYvcaedIVkQXfEKeiR6ehhvztaP/wawDY9yA3/
-        mC+fTez9V/QwIxzce/yCh8Erpes9SQ8HNj0W0CGALz6UuUa30TKB0vZVGpaxRqo0K8if0byumXdQ
-        tedQ/aDuQRUyKooL9KooyotXvtr58HSh5/se1L7TQo/62CUBw2eJFeJLHkg+mDcbvDY7HlRiyg6+
-        v37/+Ce6iZJE513lssTGCSKj50wXzHKtqfY0hu8Rl2JQKKOHCfEkYSANB8KkouFLeqALBQ0GdeGz
-        CZN2+90JL8iOHBGIvhA+P1EgtuzPCxMhXQAzFCYtXjtMoLvg/TD59Wd0uyqNAZG+RGvQ4ehem63W
-        CVqlG0hyIAe3K2U0qOuzA6ndzygwWmPuBxIXAvPTUtYjy/NgcMmhwdrLxj21QHa8qA2DEQGBbues
-        /Qbr+QRSs/1R2D0a34LnBtwFTx0/C3JQCpK43dH68Bq+NrwjgXSTpxlaaRXqHMXpElU9b9UGX8dp
-        Gb6EXtYgCKHEFF0QXaQRJj0HHDvPuYJgAhV+CjyYSXeoEYbT1wRtPFSQXmx9EasCpNrXSa3kJPq+
-        hOkEjDoKtMjTDbrRSfQBXafFukwuT+jAy8YmRD3ieZMEEJOYDI+XCMyWQEYJmxBnbr/ZrSIFtDVM
-        mNK8KkZX6Fut1zADqkdE3ehoo7WB5/boKAiYgAL3tKhrN9QF/dg4YJbGPXFSwLS17LxaRAGFZEO9
-        D4g+mAQe0iBuEBzWItDPv6Evy2S+6sz/ifIZ/gzQ8730ekFLt5baLxyE+rwagY2fmajEUBYHJdgO
-        BrH9Hlyh5/fFQzLvbNwUhWrNMnczGiUnOHjzz9M5OPa48CapCJBs4POE3Ws0tt0pqSqWrbaWCtp3
-        GHCm217G/5cZpucdF/T7o4oJw2h6kvsEAvEMgmNoOEZ2jA4cvxq9HwJQlcalEsbM9W1C2RsxL1MV
-        H40CdkIUNNuYLAo8z2e0ur0ZPftg6P5cSQZ7joaTHQUB7uf5i2efnoeM7Pyeh6G+Qv06we4BxzQQ
-        VZN+xl0azLypL929ctbrFoAMfAi2zU6ZgOpvJx+TLpfxlcnVfC2hV4DLluqiBUGDkEd6r0ewasDT
-        Xt9uYBSvb623V3I9GHrgAOw5uvHrLpQP+TzwgTkDPhhYEeH3LsXGMn6zgemMz+Am+bS628ql8zxf
-        VHJnsOxWNbca3x54PnePCMs/fkGf51qtF9CRdcLnUz295xAXzDOttSxPJxga3wk8vbr7He6pwNg1
-        D9vYjAa98d5Ynt5ziAsa/zHNvP0bd0fgfDIhAAA=
+      string: "[{\"id\":3297435983,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T17:26:31+00:00\",\"stop\":\"2024-01-26T18:00:35+00:00\",\"duration\":2044,\"description\":\"IHAC
+        using AWS WAF integration and expresses concern about the throughput\",\"tags\":[\"type:support/question\"],\"tag_ids\":[14969753],\"duronly\":true,\"at\":\"2024-01-28T08:39:01+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3297355840,\"workspace_id\":1815018,\"project_id\":28041930,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T16:34:40+00:00\",\"stop\":\"2024-01-26T17:26:32+00:00\",\"duration\":3112,\"description\":\"\U0001F68C
+        Shuttling kids between home and whatever\",\"tags\":[],\"tag_ids\":[],\"duronly\":true,\"at\":\"2024-01-26T17:26:32+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":28041930,\"permissions\":null},{\"id\":3297169916,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T14:48:28+00:00\",\"stop\":\"2024-01-26T16:34:41+00:00\",\"duration\":6373,\"description\":\"S3
+        SQS ingest delay in performance with Elastic Agent #4264\",\"tags\":[\"type:support/sdh\"],\"tag_ids\":[15007828],\"duronly\":true,\"at\":\"2024-01-26T16:34:41+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3297063846,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T13:50:21+00:00\",\"stop\":\"2024-01-26T14:48:28+00:00\",\"duration\":3487,\"description\":\"Migrate
+        to ecs@mappings template shipped with Elasticsearch [step 3]\",\"tags\":[\"type:goal\"],\"tag_ids\":[12078063],\"duronly\":true,\"at\":\"2024-01-26T14:48:28+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3297055770,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T13:45:19+00:00\",\"stop\":\"2024-01-26T13:50:21+00:00\",\"duration\":302,\"description\":\"sync\",\"tags\":[\"type:sync\"],\"tag_ids\":[12078061],\"duronly\":true,\"at\":\"2024-01-26T13:50:21+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3296925719,\"workspace_id\":1815018,\"project_id\":28041930,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T12:20:36+00:00\",\"stop\":\"2024-01-26T13:45:19+00:00\",\"duration\":5083,\"description\":\"\U0001F35C
+        Lunch\",\"tags\":[],\"tag_ids\":[],\"duronly\":true,\"at\":\"2024-01-26T13:45:19+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":28041930,\"permissions\":null},{\"id\":3296620722,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T08:44:02+00:00\",\"stop\":\"2024-01-26T12:20:37+00:00\",\"duration\":12995,\"description\":\"Migrate
+        to ecs@mappings template shipped with Elasticsearch [step 3]\",\"tags\":[\"type:goal\"],\"tag_ids\":[12078063],\"duronly\":true,\"at\":\"2024-01-26T12:20:37+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3296545927,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T07:48:47+00:00\",\"stop\":\"2024-01-26T08:44:02+00:00\",\"duration\":3315,\"description\":\"sync\",\"tags\":[\"type:sync\"],\"tag_ids\":[12078061],\"duronly\":true,\"at\":\"2024-01-26T08:44:02+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null}]"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Cache-Control:
       - no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0
-      Content-Encoding:
-      - gzip
+      Content-Length:
+      - '3477'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 03 Feb 2023 07:48:05 GMT
+      - Fri, 26 Apr 2024 04:59:25 GMT
       Instance:
-      - time-public-api2
+      - track-public-api-proxy-f666f86df-kw6z2
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=15552000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
       Via:
       - 1.1 google
       X-Content-Type-Options:
       - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
       X-Request-ID:
-      - 1012c9aa6eee4f312cfe0bf58f2b58cf
+      - 897d535931d277836816d090b258ffb8
       X-Service-Level:
       - GREEN
       X-Toggl-Request-Id:
-      - 1012c9aa6eee4f312cfe0bf58f2b58cf
+      - 3793cb3a-97c0-4ff7-9864-ccadfc5a6c49
       X-We-are-hiring:
       - https://toggl.com/jobs/
     status:

--- a/tests/cassettes/test_entries_group_by/test_group_by_tags_and_filter.yaml
+++ b/tests/cassettes/test_entries_group_by/test_group_by_tags_and_filter.yaml
@@ -9,70 +9,49 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.28.2
+      - python-requests/2.31.0
     method: GET
-    uri: https://api.track.toggl.com/api/v9/me/time_entries?start_date=2023-01-26T00%3A00%3A00Z&end_date=2023-01-27T00%3A00%3A00Z
+    uri: https://api.track.toggl.com/api/v9/me/time_entries?start_date=2024-01-26T00%3A00%3A00Z&end_date=2024-01-27T00%3A00%3A00Z
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAEA9WZ3Y7jNBTHX8XKLR3JH7GT+G6ZYaWVQCDNSkisViNP47bZpklInC2ziDdgJa4R
-        Ele8AE/GI3CSJpO6KZluacIg9aZO1Nrndz7+5/jNj04UOpL6JCCU48CbOds0XxeZmuu76gnxCcfE
-        nzlZnr7Tc7Nb9HyXcY/CslHFul5LyjieOfdRHKv7WDtyoeJCz5zCqNw40qGYsitMrqh4TamkXDL+
-        GcYSY6d6J816r3BXMvYdPA3LXJkoTWAvHoN/DHUxz6Nst+Rcp5tNmUTmQaIXcZxuUabyIkqWKF2g
-        V9+8F0iFYa6LQhcoSuCz1IVBWZTpOEo0/LpRy8KRbxzzkGlZlFmWwnbf1utwrOoRodjzscCwCFtJ
-        k/jBkSYv4Wyqf7B6193BdP5e53ehjrXR4V31/s5MZQHLteEFJYyxmVNa37a26etvrc1/mnXMsE+p
-        oFMwI9LlkpDuaMeY1VhtZtSl7gCzl9EPj8R0nqc5mseRTgARcEBRge5jlayRSkIA+a4Edgt4x0Qb
-        fWvUJrs8wAPPnAKgO0nQ7QDiIYANYxsg+T/Qo1eYvcaedIVkQXfEKeiR6ehhvztaP/wawDY9yA3/
-        mC+fTez9V/QwIxzce/yCh8Erpes9SQ8HNj0W0CGALz6UuUa30TKB0vZVGpaxRqo0K8if0byumXdQ
-        tedQ/aDuQRUyKooL9KooyotXvtr58HSh5/se1L7TQo/62CUBw2eJFeJLHkg+mDcbvDY7HlRiyg6+
-        v37/+Ce6iZJE513lssTGCSKj50wXzHKtqfY0hu8Rl2JQKKOHCfEkYSANB8KkouFLeqALBQ0GdeGz
-        CZN2+90JL8iOHBGIvhA+P1EgtuzPCxMhXQAzFCYtXjtMoLvg/TD59Wd0uyqNAZG+RGvQ4ehem63W
-        CVqlG0hyIAe3K2U0qOuzA6ndzygwWmPuBxIXAvPTUtYjy/NgcMmhwdrLxj21QHa8qA2DEQGBbues
-        /Qbr+QRSs/1R2D0a34LnBtwFTx0/C3JQCpK43dH68Bq+NrwjgXSTpxlaaRXqHMXpElU9b9UGX8dp
-        Gb6EXtYgCKHEFF0QXaQRJj0HHDvPuYJgAhV+CjyYSXeoEYbT1wRtPFSQXmx9EasCpNrXSa3kJPq+
-        hOkEjDoKtMjTDbrRSfQBXafFukwuT+jAy8YmRD3ieZMEEJOYDI+XCMyWQEYJmxBnbr/ZrSIFtDVM
-        mNK8KkZX6Fut1zADqkdE3ehoo7WB5/boKAiYgAL3tKhrN9QF/dg4YJbGPXFSwLS17LxaRAGFZEO9
-        D4g+mAQe0iBuEBzWItDPv6Evy2S+6sz/ifIZ/gzQ8730ekFLt5baLxyE+rwagY2fmajEUBYHJdgO
-        BrH9Hlyh5/fFQzLvbNwUhWrNMnczGiUnOHjzz9M5OPa48CapCJBs4POE3Ws0tt0pqSqWrbaWCtp3
-        GHCm217G/5cZpucdF/T7o4oJw2h6kvsEAvEMgmNoOEZ2jA4cvxq9HwJQlcalEsbM9W1C2RsxL1MV
-        H40CdkIUNNuYLAo8z2e0ur0ZPftg6P5cSQZ7joaTHQUB7uf5i2efnoeM7Pyeh6G+Qv06we4BxzQQ
-        VZN+xl0azLypL929ctbrFoAMfAi2zU6ZgOpvJx+TLpfxlcnVfC2hV4DLluqiBUGDkEd6r0ewasDT
-        Xt9uYBSvb623V3I9GHrgAOw5uvHrLpQP+TzwgTkDPhhYEeH3LsXGMn6zgemMz+Am+bS628ql8zxf
-        VHJnsOxWNbca3x54PnePCMs/fkGf51qtF9CRdcLnUz295xAXzDOttSxPJxga3wk8vbr7He6pwNg1
-        D9vYjAa98d5Ynt5ziAsa/zHNvP0bd0fgfDIhAAA=
+      string: "[{\"id\":3297435983,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T17:26:31+00:00\",\"stop\":\"2024-01-26T18:00:35+00:00\",\"duration\":2044,\"description\":\"IHAC
+        using AWS WAF integration and expresses concern about the throughput\",\"tags\":[\"type:support/question\"],\"tag_ids\":[14969753],\"duronly\":true,\"at\":\"2024-01-28T08:39:01+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3297355840,\"workspace_id\":1815018,\"project_id\":28041930,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T16:34:40+00:00\",\"stop\":\"2024-01-26T17:26:32+00:00\",\"duration\":3112,\"description\":\"\U0001F68C
+        Shuttling kids between home and whatever\",\"tags\":[],\"tag_ids\":[],\"duronly\":true,\"at\":\"2024-01-26T17:26:32+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":28041930,\"permissions\":null},{\"id\":3297169916,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T14:48:28+00:00\",\"stop\":\"2024-01-26T16:34:41+00:00\",\"duration\":6373,\"description\":\"S3
+        SQS ingest delay in performance with Elastic Agent #4264\",\"tags\":[\"type:support/sdh\"],\"tag_ids\":[15007828],\"duronly\":true,\"at\":\"2024-01-26T16:34:41+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3297063846,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T13:50:21+00:00\",\"stop\":\"2024-01-26T14:48:28+00:00\",\"duration\":3487,\"description\":\"Migrate
+        to ecs@mappings template shipped with Elasticsearch [step 3]\",\"tags\":[\"type:goal\"],\"tag_ids\":[12078063],\"duronly\":true,\"at\":\"2024-01-26T14:48:28+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3297055770,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T13:45:19+00:00\",\"stop\":\"2024-01-26T13:50:21+00:00\",\"duration\":302,\"description\":\"sync\",\"tags\":[\"type:sync\"],\"tag_ids\":[12078061],\"duronly\":true,\"at\":\"2024-01-26T13:50:21+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3296925719,\"workspace_id\":1815018,\"project_id\":28041930,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T12:20:36+00:00\",\"stop\":\"2024-01-26T13:45:19+00:00\",\"duration\":5083,\"description\":\"\U0001F35C
+        Lunch\",\"tags\":[],\"tag_ids\":[],\"duronly\":true,\"at\":\"2024-01-26T13:45:19+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":28041930,\"permissions\":null},{\"id\":3296620722,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T08:44:02+00:00\",\"stop\":\"2024-01-26T12:20:37+00:00\",\"duration\":12995,\"description\":\"Migrate
+        to ecs@mappings template shipped with Elasticsearch [step 3]\",\"tags\":[\"type:goal\"],\"tag_ids\":[12078063],\"duronly\":true,\"at\":\"2024-01-26T12:20:37+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3296545927,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T07:48:47+00:00\",\"stop\":\"2024-01-26T08:44:02+00:00\",\"duration\":3315,\"description\":\"sync\",\"tags\":[\"type:sync\"],\"tag_ids\":[12078061],\"duronly\":true,\"at\":\"2024-01-26T08:44:02+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null}]"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Cache-Control:
       - no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0
-      Content-Encoding:
-      - gzip
+      Content-Length:
+      - '3477'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 03 Feb 2023 07:48:05 GMT
+      - Fri, 26 Apr 2024 04:59:26 GMT
       Instance:
-      - time-public-api2
+      - track-public-api-proxy-f666f86df-kw6z2
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=15552000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
       Via:
       - 1.1 google
       X-Content-Type-Options:
       - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
       X-Request-ID:
-      - 3461241a983f5db01e7ae9f26b929aeb
+      - f880e24c3ce7558d415adb16041056af
       X-Service-Level:
       - GREEN
       X-Toggl-Request-Id:
-      - 3461241a983f5db01e7ae9f26b929aeb
+      - 9792dcae-f1d7-43fc-82e2-940d9820b3f0
       X-We-are-hiring:
       - https://toggl.com/jobs/
     status:

--- a/tests/cassettes/test_entries_list/test_list.yaml
+++ b/tests/cassettes/test_entries_list/test_list.yaml
@@ -9,70 +9,43 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.28.2
+      - python-requests/2.31.0
     method: GET
-    uri: https://api.track.toggl.com/api/v9/me/time_entries?start_date=2023-01-26T00%3A00%3A00Z&end_date=2023-01-27T00%3A00%3A00Z
+    uri: https://api.track.toggl.com/api/v9/me/time_entries?start_date=2024-02-26T00%3A00%3A00Z&end_date=2024-02-27T00%3A00%3A00Z
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAEA9WZ3Y7jNBTHX8XKLR3JH7GT+G6ZYaWVQCDNSkisViNP47bZpklInC2ziDdgJa4R
-        Ele8AE/GI3CSJpO6KZluacIg9aZO1Nrndz7+5/jNj04UOpL6JCCU48CbOds0XxeZmuu76gnxCcfE
-        nzlZnr7Tc7Nb9HyXcY/CslHFul5LyjieOfdRHKv7WDtyoeJCz5zCqNw40qGYsitMrqh4TamkXDL+
-        GcYSY6d6J816r3BXMvYdPA3LXJkoTWAvHoN/DHUxz6Nst+Rcp5tNmUTmQaIXcZxuUabyIkqWKF2g
-        V9+8F0iFYa6LQhcoSuCz1IVBWZTpOEo0/LpRy8KRbxzzkGlZlFmWwnbf1utwrOoRodjzscCwCFtJ
-        k/jBkSYv4Wyqf7B6193BdP5e53ehjrXR4V31/s5MZQHLteEFJYyxmVNa37a26etvrc1/mnXMsE+p
-        oFMwI9LlkpDuaMeY1VhtZtSl7gCzl9EPj8R0nqc5mseRTgARcEBRge5jlayRSkIA+a4Edgt4x0Qb
-        fWvUJrs8wAPPnAKgO0nQ7QDiIYANYxsg+T/Qo1eYvcaedIVkQXfEKeiR6ehhvztaP/wawDY9yA3/
-        mC+fTez9V/QwIxzce/yCh8Erpes9SQ8HNj0W0CGALz6UuUa30TKB0vZVGpaxRqo0K8if0byumXdQ
-        tedQ/aDuQRUyKooL9KooyotXvtr58HSh5/se1L7TQo/62CUBw2eJFeJLHkg+mDcbvDY7HlRiyg6+
-        v37/+Ce6iZJE513lssTGCSKj50wXzHKtqfY0hu8Rl2JQKKOHCfEkYSANB8KkouFLeqALBQ0GdeGz
-        CZN2+90JL8iOHBGIvhA+P1EgtuzPCxMhXQAzFCYtXjtMoLvg/TD59Wd0uyqNAZG+RGvQ4ehem63W
-        CVqlG0hyIAe3K2U0qOuzA6ndzygwWmPuBxIXAvPTUtYjy/NgcMmhwdrLxj21QHa8qA2DEQGBbues
-        /Qbr+QRSs/1R2D0a34LnBtwFTx0/C3JQCpK43dH68Bq+NrwjgXSTpxlaaRXqHMXpElU9b9UGX8dp
-        Gb6EXtYgCKHEFF0QXaQRJj0HHDvPuYJgAhV+CjyYSXeoEYbT1wRtPFSQXmx9EasCpNrXSa3kJPq+
-        hOkEjDoKtMjTDbrRSfQBXafFukwuT+jAy8YmRD3ieZMEEJOYDI+XCMyWQEYJmxBnbr/ZrSIFtDVM
-        mNK8KkZX6Fut1zADqkdE3ehoo7WB5/boKAiYgAL3tKhrN9QF/dg4YJbGPXFSwLS17LxaRAGFZEO9
-        D4g+mAQe0iBuEBzWItDPv6Evy2S+6sz/ifIZ/gzQ8730ekFLt5baLxyE+rwagY2fmajEUBYHJdgO
-        BrH9Hlyh5/fFQzLvbNwUhWrNMnczGiUnOHjzz9M5OPa48CapCJBs4POE3Ws0tt0pqSqWrbaWCtp3
-        GHCm217G/5cZpucdF/T7o4oJw2h6kvsEAvEMgmNoOEZ2jA4cvxq9HwJQlcalEsbM9W1C2RsxL1MV
-        H40CdkIUNNuYLAo8z2e0ur0ZPftg6P5cSQZ7joaTHQUB7uf5i2efnoeM7Pyeh6G+Qv06we4BxzQQ
-        VZN+xl0azLypL929ctbrFoAMfAi2zU6ZgOpvJx+TLpfxlcnVfC2hV4DLluqiBUGDkEd6r0ewasDT
-        Xt9uYBSvb623V3I9GHrgAOw5uvHrLpQP+TzwgTkDPhhYEeH3LsXGMn6zgemMz+Am+bS628ql8zxf
-        VHJnsOxWNbca3x54PnePCMs/fkGf51qtF9CRdcLnUz295xAXzDOttSxPJxga3wk8vbr7He6pwNg1
-        D9vYjAa98d5Ynt5ziAsa/zHNvP0bd0fgfDIhAAA=
+      string: '[{"id":3338599469,"workspace_id":1815018,"project_id":28041930,"task_id":null,"billable":false,"start":"2024-02-26T10:03:12+00:00","stop":"2024-02-26T12:07:38+00:00","duration":7466,"description":"Ristrutturazione","tags":[],"tag_ids":[],"duronly":true,"at":"2024-02-26T12:07:39+00:00","server_deleted_at":null,"user_id":2621333,"uid":2621333,"wid":1815018,"pid":28041930,"permissions":null}]'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Cache-Control:
       - no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0
-      Content-Encoding:
-      - gzip
+      Content-Length:
+      - '392'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 03 Feb 2023 07:48:05 GMT
+      - Fri, 26 Apr 2024 04:47:25 GMT
       Instance:
-      - time-public-api2
+      - track-public-api-proxy-f666f86df-ng2v4
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=15552000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
       Via:
       - 1.1 google
       X-Content-Type-Options:
       - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
       X-Request-ID:
-      - d37a26641b2eb9d772d2e2ad8364d785
+      - fec1857ad203b22c477f1a1de73c3423
       X-Service-Level:
       - GREEN
       X-Toggl-Request-Id:
-      - d37a26641b2eb9d772d2e2ad8364d785
+      - 920abb6c-acb0-4178-9551-ec71751ac95c
       X-We-are-hiring:
       - https://toggl.com/jobs/
     status:

--- a/tests/cassettes/test_entries_list/test_list_as_ndjson.yaml
+++ b/tests/cassettes/test_entries_list/test_list_as_ndjson.yaml
@@ -9,70 +9,49 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.28.2
+      - python-requests/2.31.0
     method: GET
-    uri: https://api.track.toggl.com/api/v9/me/time_entries?start_date=2023-01-26T00%3A00%3A00Z&end_date=2023-01-27T00%3A00%3A00Z
+    uri: https://api.track.toggl.com/api/v9/me/time_entries?start_date=2024-01-26T00%3A00%3A00Z&end_date=2024-01-27T00%3A00%3A00Z
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAEA9WZ3Y7jNBTHX8XKLR3JH7GT+G6ZYaWVQCDNSkisViNP47bZpklInC2ziDdgJa4R
-        Ele8AE/GI3CSJpO6KZluacIg9aZO1Nrndz7+5/jNj04UOpL6JCCU48CbOds0XxeZmuu76gnxCcfE
-        nzlZnr7Tc7Nb9HyXcY/CslHFul5LyjieOfdRHKv7WDtyoeJCz5zCqNw40qGYsitMrqh4TamkXDL+
-        GcYSY6d6J816r3BXMvYdPA3LXJkoTWAvHoN/DHUxz6Nst+Rcp5tNmUTmQaIXcZxuUabyIkqWKF2g
-        V9+8F0iFYa6LQhcoSuCz1IVBWZTpOEo0/LpRy8KRbxzzkGlZlFmWwnbf1utwrOoRodjzscCwCFtJ
-        k/jBkSYv4Wyqf7B6193BdP5e53ehjrXR4V31/s5MZQHLteEFJYyxmVNa37a26etvrc1/mnXMsE+p
-        oFMwI9LlkpDuaMeY1VhtZtSl7gCzl9EPj8R0nqc5mseRTgARcEBRge5jlayRSkIA+a4Edgt4x0Qb
-        fWvUJrs8wAPPnAKgO0nQ7QDiIYANYxsg+T/Qo1eYvcaedIVkQXfEKeiR6ehhvztaP/wawDY9yA3/
-        mC+fTez9V/QwIxzce/yCh8Erpes9SQ8HNj0W0CGALz6UuUa30TKB0vZVGpaxRqo0K8if0byumXdQ
-        tedQ/aDuQRUyKooL9KooyotXvtr58HSh5/se1L7TQo/62CUBw2eJFeJLHkg+mDcbvDY7HlRiyg6+
-        v37/+Ce6iZJE513lssTGCSKj50wXzHKtqfY0hu8Rl2JQKKOHCfEkYSANB8KkouFLeqALBQ0GdeGz
-        CZN2+90JL8iOHBGIvhA+P1EgtuzPCxMhXQAzFCYtXjtMoLvg/TD59Wd0uyqNAZG+RGvQ4ehem63W
-        CVqlG0hyIAe3K2U0qOuzA6ndzygwWmPuBxIXAvPTUtYjy/NgcMmhwdrLxj21QHa8qA2DEQGBbues
-        /Qbr+QRSs/1R2D0a34LnBtwFTx0/C3JQCpK43dH68Bq+NrwjgXSTpxlaaRXqHMXpElU9b9UGX8dp
-        Gb6EXtYgCKHEFF0QXaQRJj0HHDvPuYJgAhV+CjyYSXeoEYbT1wRtPFSQXmx9EasCpNrXSa3kJPq+
-        hOkEjDoKtMjTDbrRSfQBXafFukwuT+jAy8YmRD3ieZMEEJOYDI+XCMyWQEYJmxBnbr/ZrSIFtDVM
-        mNK8KkZX6Fut1zADqkdE3ehoo7WB5/boKAiYgAL3tKhrN9QF/dg4YJbGPXFSwLS17LxaRAGFZEO9
-        D4g+mAQe0iBuEBzWItDPv6Evy2S+6sz/ifIZ/gzQ8730ekFLt5baLxyE+rwagY2fmajEUBYHJdgO
-        BrH9Hlyh5/fFQzLvbNwUhWrNMnczGiUnOHjzz9M5OPa48CapCJBs4POE3Ws0tt0pqSqWrbaWCtp3
-        GHCm217G/5cZpucdF/T7o4oJw2h6kvsEAvEMgmNoOEZ2jA4cvxq9HwJQlcalEsbM9W1C2RsxL1MV
-        H40CdkIUNNuYLAo8z2e0ur0ZPftg6P5cSQZ7joaTHQUB7uf5i2efnoeM7Pyeh6G+Qv06we4BxzQQ
-        VZN+xl0azLypL929ctbrFoAMfAi2zU6ZgOpvJx+TLpfxlcnVfC2hV4DLluqiBUGDkEd6r0ewasDT
-        Xt9uYBSvb623V3I9GHrgAOw5uvHrLpQP+TzwgTkDPhhYEeH3LsXGMn6zgemMz+Am+bS628ql8zxf
-        VHJnsOxWNbca3x54PnePCMs/fkGf51qtF9CRdcLnUz295xAXzDOttSxPJxga3wk8vbr7He6pwNg1
-        D9vYjAa98d5Ynt5ziAsa/zHNvP0bd0fgfDIhAAA=
+      string: "[{\"id\":3297435983,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T17:26:31+00:00\",\"stop\":\"2024-01-26T18:00:35+00:00\",\"duration\":2044,\"description\":\"IHAC
+        using AWS WAF integration and expresses concern about the throughput\",\"tags\":[\"type:support/question\"],\"tag_ids\":[14969753],\"duronly\":true,\"at\":\"2024-01-28T08:39:01+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3297355840,\"workspace_id\":1815018,\"project_id\":28041930,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T16:34:40+00:00\",\"stop\":\"2024-01-26T17:26:32+00:00\",\"duration\":3112,\"description\":\"\U0001F68C
+        Shuttling kids between home and whatever\",\"tags\":[],\"tag_ids\":[],\"duronly\":true,\"at\":\"2024-01-26T17:26:32+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":28041930,\"permissions\":null},{\"id\":3297169916,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T14:48:28+00:00\",\"stop\":\"2024-01-26T16:34:41+00:00\",\"duration\":6373,\"description\":\"S3
+        SQS ingest delay in performance with Elastic Agent #4264\",\"tags\":[\"type:support/sdh\"],\"tag_ids\":[15007828],\"duronly\":true,\"at\":\"2024-01-26T16:34:41+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3297063846,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T13:50:21+00:00\",\"stop\":\"2024-01-26T14:48:28+00:00\",\"duration\":3487,\"description\":\"Migrate
+        to ecs@mappings template shipped with Elasticsearch [step 3]\",\"tags\":[\"type:goal\"],\"tag_ids\":[12078063],\"duronly\":true,\"at\":\"2024-01-26T14:48:28+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3297055770,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T13:45:19+00:00\",\"stop\":\"2024-01-26T13:50:21+00:00\",\"duration\":302,\"description\":\"sync\",\"tags\":[\"type:sync\"],\"tag_ids\":[12078061],\"duronly\":true,\"at\":\"2024-01-26T13:50:21+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3296925719,\"workspace_id\":1815018,\"project_id\":28041930,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T12:20:36+00:00\",\"stop\":\"2024-01-26T13:45:19+00:00\",\"duration\":5083,\"description\":\"\U0001F35C
+        Lunch\",\"tags\":[],\"tag_ids\":[],\"duronly\":true,\"at\":\"2024-01-26T13:45:19+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":28041930,\"permissions\":null},{\"id\":3296620722,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T08:44:02+00:00\",\"stop\":\"2024-01-26T12:20:37+00:00\",\"duration\":12995,\"description\":\"Migrate
+        to ecs@mappings template shipped with Elasticsearch [step 3]\",\"tags\":[\"type:goal\"],\"tag_ids\":[12078063],\"duronly\":true,\"at\":\"2024-01-26T12:20:37+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3296545927,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T07:48:47+00:00\",\"stop\":\"2024-01-26T08:44:02+00:00\",\"duration\":3315,\"description\":\"sync\",\"tags\":[\"type:sync\"],\"tag_ids\":[12078061],\"duronly\":true,\"at\":\"2024-01-26T08:44:02+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null}]"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Cache-Control:
       - no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0
-      Content-Encoding:
-      - gzip
+      Content-Length:
+      - '3477'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 07 Feb 2023 05:26:12 GMT
+      - Fri, 26 Apr 2024 04:47:26 GMT
       Instance:
-      - time-public-api
+      - track-public-api-proxy-f666f86df-ng2v4
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=15552000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
       Via:
       - 1.1 google
       X-Content-Type-Options:
       - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
       X-Request-ID:
-      - dd0d87870fbc46bc714cffb130004d03
+      - 7a2ddb0c5d7e625326f5bed2386b57ca
       X-Service-Level:
       - GREEN
       X-Toggl-Request-Id:
-      - dd0d87870fbc46bc714cffb130004d03
+      - c8eba609-831f-42c8-be20-bf6872bf5e6e
       X-We-are-hiring:
       - https://toggl.com/jobs/
     status:

--- a/tests/cassettes/test_entries_list/test_list_filter_by_description.yaml
+++ b/tests/cassettes/test_entries_list/test_list_filter_by_description.yaml
@@ -9,70 +9,49 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.28.2
+      - python-requests/2.31.0
     method: GET
-    uri: https://api.track.toggl.com/api/v9/me/time_entries?start_date=2023-01-26T00%3A00%3A00Z&end_date=2023-01-27T00%3A00%3A00Z
+    uri: https://api.track.toggl.com/api/v9/me/time_entries?start_date=2024-01-26T00%3A00%3A00Z&end_date=2024-01-27T00%3A00%3A00Z
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAEA9WZ3Y7jNBTHX8XKLR3JH7GT+G6ZYaWVQCDNSkisViNP47bZpklInC2ziDdgJa4R
-        Ele8AE/GI3CSJpO6KZluacIg9aZO1Nrndz7+5/jNj04UOpL6JCCU48CbOds0XxeZmuu76gnxCcfE
-        nzlZnr7Tc7Nb9HyXcY/CslHFul5LyjieOfdRHKv7WDtyoeJCz5zCqNw40qGYsitMrqh4TamkXDL+
-        GcYSY6d6J816r3BXMvYdPA3LXJkoTWAvHoN/DHUxz6Nst+Rcp5tNmUTmQaIXcZxuUabyIkqWKF2g
-        V9+8F0iFYa6LQhcoSuCz1IVBWZTpOEo0/LpRy8KRbxzzkGlZlFmWwnbf1utwrOoRodjzscCwCFtJ
-        k/jBkSYv4Wyqf7B6193BdP5e53ehjrXR4V31/s5MZQHLteEFJYyxmVNa37a26etvrc1/mnXMsE+p
-        oFMwI9LlkpDuaMeY1VhtZtSl7gCzl9EPj8R0nqc5mseRTgARcEBRge5jlayRSkIA+a4Edgt4x0Qb
-        fWvUJrs8wAPPnAKgO0nQ7QDiIYANYxsg+T/Qo1eYvcaedIVkQXfEKeiR6ehhvztaP/wawDY9yA3/
-        mC+fTez9V/QwIxzce/yCh8Erpes9SQ8HNj0W0CGALz6UuUa30TKB0vZVGpaxRqo0K8if0byumXdQ
-        tedQ/aDuQRUyKooL9KooyotXvtr58HSh5/se1L7TQo/62CUBw2eJFeJLHkg+mDcbvDY7HlRiyg6+
-        v37/+Ce6iZJE513lssTGCSKj50wXzHKtqfY0hu8Rl2JQKKOHCfEkYSANB8KkouFLeqALBQ0GdeGz
-        CZN2+90JL8iOHBGIvhA+P1EgtuzPCxMhXQAzFCYtXjtMoLvg/TD59Wd0uyqNAZG+RGvQ4ehem63W
-        CVqlG0hyIAe3K2U0qOuzA6ndzygwWmPuBxIXAvPTUtYjy/NgcMmhwdrLxj21QHa8qA2DEQGBbues
-        /Qbr+QRSs/1R2D0a34LnBtwFTx0/C3JQCpK43dH68Bq+NrwjgXSTpxlaaRXqHMXpElU9b9UGX8dp
-        Gb6EXtYgCKHEFF0QXaQRJj0HHDvPuYJgAhV+CjyYSXeoEYbT1wRtPFSQXmx9EasCpNrXSa3kJPq+
-        hOkEjDoKtMjTDbrRSfQBXafFukwuT+jAy8YmRD3ieZMEEJOYDI+XCMyWQEYJmxBnbr/ZrSIFtDVM
-        mNK8KkZX6Fut1zADqkdE3ehoo7WB5/boKAiYgAL3tKhrN9QF/dg4YJbGPXFSwLS17LxaRAGFZEO9
-        D4g+mAQe0iBuEBzWItDPv6Evy2S+6sz/ifIZ/gzQ8730ekFLt5baLxyE+rwagY2fmajEUBYHJdgO
-        BrH9Hlyh5/fFQzLvbNwUhWrNMnczGiUnOHjzz9M5OPa48CapCJBs4POE3Ws0tt0pqSqWrbaWCtp3
-        GHCm217G/5cZpucdF/T7o4oJw2h6kvsEAvEMgmNoOEZ2jA4cvxq9HwJQlcalEsbM9W1C2RsxL1MV
-        H40CdkIUNNuYLAo8z2e0ur0ZPftg6P5cSQZ7joaTHQUB7uf5i2efnoeM7Pyeh6G+Qv06we4BxzQQ
-        VZN+xl0azLypL929ctbrFoAMfAi2zU6ZgOpvJx+TLpfxlcnVfC2hV4DLluqiBUGDkEd6r0ewasDT
-        Xt9uYBSvb623V3I9GHrgAOw5uvHrLpQP+TzwgTkDPhhYEeH3LsXGMn6zgemMz+Am+bS628ql8zxf
-        VHJnsOxWNbca3x54PnePCMs/fkGf51qtF9CRdcLnUz295xAXzDOttSxPJxga3wk8vbr7He6pwNg1
-        D9vYjAa98d5Ynt5ziAsa/zHNvP0bd0fgfDIhAAA=
+      string: "[{\"id\":3297435983,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T17:26:31+00:00\",\"stop\":\"2024-01-26T18:00:35+00:00\",\"duration\":2044,\"description\":\"IHAC
+        using AWS WAF integration and expresses concern about the throughput\",\"tags\":[\"type:support/question\"],\"tag_ids\":[14969753],\"duronly\":true,\"at\":\"2024-01-28T08:39:01+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3297355840,\"workspace_id\":1815018,\"project_id\":28041930,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T16:34:40+00:00\",\"stop\":\"2024-01-26T17:26:32+00:00\",\"duration\":3112,\"description\":\"\U0001F68C
+        Shuttling kids between home and whatever\",\"tags\":[],\"tag_ids\":[],\"duronly\":true,\"at\":\"2024-01-26T17:26:32+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":28041930,\"permissions\":null},{\"id\":3297169916,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T14:48:28+00:00\",\"stop\":\"2024-01-26T16:34:41+00:00\",\"duration\":6373,\"description\":\"S3
+        SQS ingest delay in performance with Elastic Agent #4264\",\"tags\":[\"type:support/sdh\"],\"tag_ids\":[15007828],\"duronly\":true,\"at\":\"2024-01-26T16:34:41+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3297063846,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T13:50:21+00:00\",\"stop\":\"2024-01-26T14:48:28+00:00\",\"duration\":3487,\"description\":\"Migrate
+        to ecs@mappings template shipped with Elasticsearch [step 3]\",\"tags\":[\"type:goal\"],\"tag_ids\":[12078063],\"duronly\":true,\"at\":\"2024-01-26T14:48:28+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3297055770,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T13:45:19+00:00\",\"stop\":\"2024-01-26T13:50:21+00:00\",\"duration\":302,\"description\":\"sync\",\"tags\":[\"type:sync\"],\"tag_ids\":[12078061],\"duronly\":true,\"at\":\"2024-01-26T13:50:21+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3296925719,\"workspace_id\":1815018,\"project_id\":28041930,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T12:20:36+00:00\",\"stop\":\"2024-01-26T13:45:19+00:00\",\"duration\":5083,\"description\":\"\U0001F35C
+        Lunch\",\"tags\":[],\"tag_ids\":[],\"duronly\":true,\"at\":\"2024-01-26T13:45:19+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":28041930,\"permissions\":null},{\"id\":3296620722,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T08:44:02+00:00\",\"stop\":\"2024-01-26T12:20:37+00:00\",\"duration\":12995,\"description\":\"Migrate
+        to ecs@mappings template shipped with Elasticsearch [step 3]\",\"tags\":[\"type:goal\"],\"tag_ids\":[12078063],\"duronly\":true,\"at\":\"2024-01-26T12:20:37+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null},{\"id\":3296545927,\"workspace_id\":1815018,\"project_id\":178435728,\"task_id\":null,\"billable\":false,\"start\":\"2024-01-26T07:48:47+00:00\",\"stop\":\"2024-01-26T08:44:02+00:00\",\"duration\":3315,\"description\":\"sync\",\"tags\":[\"type:sync\"],\"tag_ids\":[12078061],\"duronly\":true,\"at\":\"2024-01-26T08:44:02+00:00\",\"server_deleted_at\":null,\"user_id\":2621333,\"uid\":2621333,\"wid\":1815018,\"pid\":178435728,\"permissions\":null}]"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Cache-Control:
       - no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0
-      Content-Encoding:
-      - gzip
+      Content-Length:
+      - '3477'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 03 Feb 2023 07:48:05 GMT
+      - Fri, 26 Apr 2024 04:47:25 GMT
       Instance:
-      - time-public-api2
+      - track-public-api-proxy-f666f86df-kw6z2
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=15552000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
       Via:
       - 1.1 google
       X-Content-Type-Options:
       - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
       X-Request-ID:
-      - d37a26641b2eb9d772d2e2ad8364d785
+      - 056288aeaf3de0a192ef178fdb9c2b58
       X-Service-Level:
       - GREEN
       X-Toggl-Request-Id:
-      - d37a26641b2eb9d772d2e2ad8364d785
+      - 1fce921f-4435-4650-abb7-e636f123f3b1
       X-We-are-hiring:
       - https://toggl.com/jobs/
     status:

--- a/tests/cassettes/test_entries_list/test_list_with_a_running_time_entry.yaml
+++ b/tests/cassettes/test_entries_list/test_list_with_a_running_time_entry.yaml
@@ -9,66 +9,47 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.28.2
+      - python-requests/2.31.0
     method: GET
-    uri: https://api.track.toggl.com/api/v9/me/time_entries?start_date=2023-02-03T00%3A00%3A00Z&end_date=2023-02-05T00%3A00%3A00Z
+    uri: https://api.track.toggl.com/api/v9/me/time_entries?start_date=2024-02-03T00%3A00%3A00Z&end_date=2024-02-05T00%3A00%3A00Z
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAEA82YS46jRhiAr1JiG7dUDx5VteskijSLSFG6VxmNWtWmGjPGgKhiHCfKDRIp62x6
-        lQvkZH2E/NhgXGbkpgmORmJhY2SK7/tfxftfvTT2JOWM0IgRjhfetqjWplRL/dD8QjgJMOELr6yK
-        j3pp9ydFgKkIQ7rwrDLr/am8zrKF95hmmXrMtCefVGb0wjNWVdaTHsWU3WB6g/17HEgWScq+wlhi
-        7DXXFKUnD38Q15WyaZF78oaEUeBzgX228GJtllVaHn7xbJEk2Y2t1HItUZqbNFlZA39kVWI8+f7D
-        /hOsqv0C/1nk2c6TtqphSerV9ejqk64eYp1pq+OH5vrD4moDp/e4QkoYg3XVzretC6z51pH6bdGD
-        xtj3GRAdAZpE3GdBROHqN5Nm9xSDPon9M9K9DLiESixkEP0E+Hr2YUQG0L8pNps6T+1OotssK7ao
-        VJVJ8wQVT+jdD59CpOK40sZoA0rgSLSxqExLnaW57uV4dldqaeqyLCAwHFWE4ojjEMPJi8r6VfcP
-        NqOyI/MTZ1gw7lMyyhnl2CeCQSZNUEaEhGOQHI6y1qqrjAXN8tw8eXn+4x/0bZrnuuoFOMhHoB7E
-        0IyoO1SnpHkIeR+NIn00NQ01b1AHvA+ifR06RQ3ZEwRQHF3UkPsg10VtdvmyZ9wGeXPOwd1GOHkd
-        e3fnfnEzYj9yO+UeMQz5N4p7p20a9lD6cND+yT6HfW/GxR4EIjzH/vL81+/oblVbC1UmQWuo+ehR
-        263WOVoVG41UHqPtSlkNFb3340gZJeMsUmaU0cF0XBBBRDDKxdHlZBnQhS91CNL6cmUwAS3JTYHb
-        skR3ACZdapQVSdMGrE4O7VwiWxU1DAZmVRQ2TXKU1ctU5eUOpcbU+qR7H3InKVT22dxhI3QNImxG
-        XUfep75CHrGmJly9o4MMSiSOLiUPPH2j1PVFCIPcdoV9SR29iTI3EK/tLAgFDSCIr+8skCR4pc+0
-        Wl1nTGBxwdl36c/HGUxXVVGhZZbqHIYumKwgrdBjpvL1vgKq+GMN09gTXGPTjb6zalP21XCWkWwY
-        mdcW6Isw4uMa1jFppxVJv9mw+BcHhdaxK5BSMRgUTpPul7rS6A6qIQzM3xdxnUG/qu0KHKbL/S7o
-        ATZdS5ipobfBdsSqNDPoXVMv55Y3CNFryyOB4D5E94js22+hoghMT5mnoVpCabk4bbR6XXeEhuFg
-        3PixMCrPVU//rYPEIJJm5NxxOm1MGAtM6CjM/y1HYBNJIYgu5kirwuUcYu5fKHK3X06ODCJpRndH
-        +L08KgTz6f8yBWLeFDhCLkwVrV/hyqOcD8bAuXdC3Z37xV2bOydcROMmg+71zqTahKOmNpGwf7LB
-        TgjMwFWMuNgZ7JDPc2bOd2Lsvrtvv7QZoXfQTmM9iijB8M5pRD/oNkzTmIeyifZL/aDTcsbcDwd1
-        6uX57z/R15VW6ydl7OSu0N3wKrA7Wg7sEJPoDc132pteiCIYe4kMcP9gwwBvfbiwCcbQtNzdyswB
-        PoiDawT4h38BGti9z18XAAA=
+      string: '[{"id":3308887448,"workspace_id":1815018,"project_id":178435728,"task_id":null,"billable":false,"start":"2024-02-04T23:00:00+00:00","stop":"2024-02-05T01:09:46+00:00","duration":7786,"description":"How
+        to performance test the aws-s3 input in SQS mode","tags":["type:support/problem"],"tag_ids":[14953621],"duronly":true,"at":"2024-02-05T01:09:47+00:00","server_deleted_at":null,"user_id":2621333,"uid":2621333,"wid":1815018,"pid":178435728,"permissions":null},{"id":3308835167,"workspace_id":1815018,"project_id":178435728,"task_id":null,"billable":false,"start":"2024-02-04T21:42:16+00:00","stop":"2024-02-04T22:59:59+00:00","duration":4663,"description":"How
+        to performance test the aws-s3 input in SQS mode","tags":["type:support/problem"],"tag_ids":[14953621],"duronly":true,"at":"2024-02-04T23:35:55+00:00","server_deleted_at":null,"user_id":2621333,"uid":2621333,"wid":1815018,"pid":178435728,"permissions":null},{"id":3308734784,"workspace_id":1815018,"project_id":178435728,"task_id":null,"billable":false,"start":"2024-02-04T17:29:21+00:00","stop":"2024-02-04T19:35:35+00:00","duration":7574,"description":"How
+        to performance test the aws-s3 input in SQS mode","tags":["type:support/problem"],"tag_ids":[14953621],"duronly":true,"at":"2024-02-04T19:35:35+00:00","server_deleted_at":null,"user_id":2621333,"uid":2621333,"wid":1815018,"pid":178435728,"permissions":null},{"id":3308368569,"workspace_id":1815018,"project_id":95029662,"task_id":null,"billable":false,"start":"2024-02-03T18:07:12+00:00","stop":"2024-02-03T19:50:20+00:00","duration":6188,"description":"Learn
+        Concurrent Programming with Go","tags":[],"tag_ids":[],"duronly":true,"at":"2024-02-03T19:50:21+00:00","server_deleted_at":null,"user_id":2621333,"uid":2621333,"wid":1815018,"pid":95029662,"permissions":null}]'
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Cache-Control:
       - no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0
-      Content-Encoding:
-      - gzip
+      Content-Length:
+      - '1789'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sat, 04 Feb 2023 07:01:40 GMT
+      - Fri, 26 Apr 2024 04:47:25 GMT
       Instance:
-      - time-public-api2
+      - track-public-api-proxy-f666f86df-kw6z2
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=15552000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
       Via:
       - 1.1 google
       X-Content-Type-Options:
       - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
       X-Request-ID:
-      - 2e80bfb074c97169052b45545f846cd1
+      - c57a749da296aace80182f9c4507e794
       X-Service-Level:
       - GREEN
       X-Toggl-Request-Id:
-      - 2e80bfb074c97169052b45545f846cd1
+      - 66de3007-9210-4699-9cba-3892d39a1b73
       X-We-are-hiring:
       - https://toggl.com/jobs/
     status:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 import pytest
-from click.testing import Result
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_entries_group_by.py
+++ b/tests/test_entries_group_by.py
@@ -16,25 +16,25 @@ def test_group_by_tags(save_to_tmp):
     with runner.isolated_filesystem():
         result = runner.invoke(
             cli,
-            ["entries", "group-by", "--field", "tags", "--start-date", "2023-01-26", "--end-date", "2023-01-27"],
+            ["entries", "group-by", "--field", "tags", "--start-date", "2024-01-26", "--end-date", "2024-01-27"],
             env=env,
         )
         save_to_tmp(result.output, name="test_group_by_tags")
         assert result.exit_code == 0
         assert (
             result.output
-            == """       Time Entries        
-                           
-  tags           Duration  
- ───────────────────────── 
-  type:support   5:44      
-                 5:14      
-  type:sync      3:00      
-  type:meeting   2:04      
-  type:goal      0:35      
- ───────────────────────── 
-  Total          16:39     
-                           
+            == """            Time Entries            
+                                    
+  tags                    Duration  
+ ────────────────────────────────── 
+  type:goal               4:34      
+                          2:16      
+  type:support/sdh        1:46      
+  type:sync               1:00      
+  type:support/question   0:34      
+ ────────────────────────────────── 
+  Total                   10:11     
+                                    
 
 """
         )
@@ -47,24 +47,31 @@ def test_group_by_tags_and_filter(save_to_tmp):
     with runner.isolated_filesystem():
         result = runner.invoke(
             cli,
-            ["entries", "--project-id", "178435728", "group-by", "--field", "tags", "--start-date", "2023-01-26", "--end-date", "2023-01-27"],
+            [
+                "entries",
+                "--project-id", "178435728",
+                "group-by",
+                "--field", "tags",
+                "--start-date", "2024-01-26",
+                "--end-date", "2024-01-27"
+             ],
             env=env,
         )
         save_to_tmp(result.output, name="test_group_by_tags_and_filter")
         assert result.exit_code == 0
         assert (
             result.output
-            == """       Time Entries        
-                           
-  tags           Duration  
- ───────────────────────── 
-  type:support   5:44      
-  type:sync      3:00      
-  type:meeting   2:04      
-  type:goal      0:35      
- ───────────────────────── 
-  Total          11:24     
-                           
+            == """            Time Entries            
+                                    
+  tags                    Duration  
+ ────────────────────────────────── 
+  type:goal               4:34      
+  type:support/sdh        1:46      
+  type:sync               1:00      
+  type:support/question   0:34      
+ ────────────────────────────────── 
+  Total                   7:55      
+                                    
 
 """
         )
@@ -77,27 +84,31 @@ def test_group_by_initiative(save_to_tmp):
     with runner.isolated_filesystem():
         result = runner.invoke(
             cli,
-            ["entries", "--project-id", "178435728", "group-by", "--field", "initiative", "--start-date", "2023-01-26", "--end-date", "2023-01-27"],
+            ["entries",
+             "--project-id", "178435728",
+             "group-by",
+             "--field", "initiative",
+             "--start-date", "2024-01-26",
+             "--end-date", "2024-01-27"
+             ],
             env=env,
         )
         save_to_tmp(result.output, name="test_group_by_initiative")
         assert result.exit_code == 0
         assert (
             result.output
-            == """                      Time Entries                      
-                                                        
-  initiative                                  Duration  
- ────────────────────────────────────────────────────── 
-  Community                                   4:52      
-  sync                                        3:00      
-  Cloud Monitoring - Weekly                   1:29      
-  ElasticOnAzure                              0:43      
-  azure2                                      0:35      
-  gather town                                 0:35      
-  Drop header log line in CloudFront events   0:08      
- ────────────────────────────────────────────────────── 
-  Total                                       11:24     
-                                                        
+            == """                                  Time Entries                                  
+                                                                                
+  initiative                                                          Duration  
+ ────────────────────────────────────────────────────────────────────────────── 
+  Migrate to ecs@mappings template shipped with Elasticsearch         4:34      
+  S3 SQS ingest delay in performance with Elastic Agent #4264         1:46      
+  sync                                                                1:00      
+  IHAC using AWS WAF integration and expresses concern about the      0:34      
+  throughput                                                                    
+ ────────────────────────────────────────────────────────────────────────────── 
+  Total                                                               7:55      
+                                                                                
 
 """
         )
@@ -110,20 +121,22 @@ def test_group_by_initiative_as_ndjson(save_to_tmp):
     with runner.isolated_filesystem():
         result = runner.invoke(
             cli,
-            ["--format", "ndjson", "entries", "--project-id", "178435728", "group-by", "--field", "initiative", "--start-date", "2023-01-26", "--end-date", "2023-01-27"],
+            [
+                "--format", "ndjson",
+                "entries",
+                "--project-id", "178435728",
+                "group-by",
+                "--field", "initiative",
+                "--start-date", "2024-01-27",
+                "--end-date", "2024-01-29"
+            ],
             env=env,
         )
         save_to_tmp(result.output, name="test_group_by_initiative_as_ndjson")
         assert result.exit_code == 0
         assert (
             result.output
-            == """{"field": "initiative", "name": "Community", "duration": 17548}
-{"field": "initiative", "name": "sync", "duration": 10830}
-{"field": "initiative", "name": "Cloud Monitoring - Weekly", "duration": 5341}
-{"field": "initiative", "name": "ElasticOnAzure", "duration": 2613}
-{"field": "initiative", "name": "azure2", "duration": 2133}
-{"field": "initiative", "name": "gather town", "duration": 2110}
-{"field": "initiative", "name": "Drop header log line in CloudFront events", "duration": 505}
+            == """{"field": "initiative", "name": "synthetics kt session #2", "duration": 17928}
 """
         )
 
@@ -135,13 +148,22 @@ def test_group_by_initiative_as_json_with_root_element(save_to_tmp):
     with runner.isolated_filesystem():
         result = runner.invoke(
             cli,
-            ["--format", "json", "--json-root", "entries-by-tags", "entries", "--project-id", "178435728", "group-by", "--field", "tags", "--start-date", "2023-01-26", "--end-date", "2023-01-27"],
+            [
+                "--format", "json",
+                "--json-root", "entries-by-tags",
+                "entries",
+                "--project-id", "178435728",
+                "group-by",
+                "--field", "tags",
+                "--start-date", "2024-01-26",
+                "--end-date", "2024-01-27",
+            ],
             env=env,
         )
         save_to_tmp(result.output, name="test_group_by_initiative_as_json_with_root_element")
         assert result.exit_code == 0
         assert (
             result.output
-            == """{"entries-by-tags": [["type:support", 20666], ["type:sync", 10830], ["type:meeting", 7451], ["type:goal", 2133]]}
+            == """{"entries-by-tags": [["type:goal", 16482], ["type:support/sdh", 6373], ["type:sync", 3617], ["type:support/question", 2044]]}
 """
         )

--- a/tests/test_entries_list.py
+++ b/tests/test_entries_list.py
@@ -16,7 +16,7 @@ def test_list_filter_by_description(save_to_tmp):
     with runner.isolated_filesystem():
         result = runner.invoke(
             cli,
-            ["entries", "--description", "toggl-track", "list", "--start-date", "2023-01-26", "--end-date", "2023-01-27"],
+            ["entries", "--description", "ecs@mappings", "list", "--start-date", "2024-01-26", "--end-date", "2024-01-27"],
             env=env,
         )
         save_to_tmp(result.output, name="test_list_filter_by_description")
@@ -25,16 +25,18 @@ def test_list_filter_by_description(save_to_tmp):
             result.output
             == """                                  Time Entries                                  
                                                                                 
-  At           Description               Start      Stop       Duration   Tags  
+  At           Description          Start      Stop       Duration   Tags       
  ────────────────────────────────────────────────────────────────────────────── 
-  2023-01-26   toggl-track: list time    07:28 AM   08:08 AM   0:39             
-               entries                                                          
-  2023-01-26   toggl-track: list time    06:48 AM   07:17 AM   0:28             
-               entries                                                          
-  2023-01-26   toggl-track: list time    05:11 AM   06:06 AM   0:54             
-               entries                                                          
+  2024-01-26   Migrate to           01:50 PM   02:48 PM   0:58       type:goal  
+               ecs@mappings                                                     
+               template shipped                                                 
+               with Elasticsearch                                               
+  2024-01-26   Migrate to           08:44 AM   12:20 PM   3:36       type:goal  
+               ecs@mappings                                                     
+               template shipped                                                 
+               with Elasticsearch                                               
  ────────────────────────────────────────────────────────────────────────────── 
-                                                    Total      2:02             
+                                               Total      4:34                  
                                                                                 
 
 """
@@ -48,89 +50,26 @@ def test_list(save_to_tmp):
     with runner.isolated_filesystem():
         result = runner.invoke(
             cli,
-            ["entries", "list", "--start-date", "2023-01-26", "--end-date", "2023-01-27"],
+            [
+                "entries",
+                "list",
+                "--start-date", "2024-02-26",
+                "--end-date", "2024-02-27"
+            ],
             env=env,
         )
         save_to_tmp(result.output, name="test_list")
         assert result.exit_code == 0
         assert (
             result.output
-            == """                                  Time Entries                                  
-                                                                                
-  At           Description       Start      Stop       Duration   Tags          
- ────────────────────────────────────────────────────────────────────────────── 
-  2023-01-26   Community:        10:25 PM   10:54 PM   0:28       type:support  
-               Allow parsing                                                    
-               of IPv6                                                          
-               addresses in                                                     
-               ingest pipeline                                                  
-  2023-01-26   Community: Fix    09:45 PM   10:25 PM   0:40       type:support  
-               parsing error                                                    
-               client port is                                                   
-               blank and                                                        
-               adjust for                                                       
-               timeStamp                                                        
-  2023-02-03   Community: Fix    09:45 PM   09:45 PM   0:00       type:support  
-               parsing error                                                    
-               client port is                                                   
-               blank and                                                        
-               adjust for                                                       
-               timeStamp                                                        
-  2023-02-03   Community: Fix    09:45 PM   09:45 PM   0:00       type:support  
-               parsing error                                                    
-               client port is                                                   
-               blank and                                                        
-               adjust for                                                       
-               timeStamp                                                        
-  2023-01-26   Community:        08:39 PM   09:45 PM   1:05       type:support  
-               Azure Signin                                                     
-               Module                                                           
-               authentication…                                                  
-               Issue                                                            
-  2023-01-26   🍲 Dinner         06:59 PM   08:39 PM   1:39                     
-  2023-01-26   Community:        05:13 PM   06:58 PM   1:44       type:support  
-               Azure Signin                                                     
-               Module                                                           
-               authentication…                                                  
-               Issue                                                            
-  2023-01-26   🚌 Shuttling      04:48 PM   05:13 PM   0:25                     
-               kids between                                                     
-               home and                                                         
-               whatever                                                         
-  2023-01-26   Community:        03:55 PM   04:48 PM   0:52       type:support  
-               Azure Signin                                                     
-               Module                                                           
-               authentication…                                                  
-               Issue                                                            
-  2023-01-26   Drop header log   03:47 PM   03:55 PM   0:08       type:support  
-               line in                                                          
-               CloudFront                                                       
-               events                                                           
-  2023-01-26   ElasticOnAzure:   03:03 PM   03:47 PM   0:43       type:support  
-               questions from                                                   
-               Deniz Coskun                                                     
-  2023-01-26   Cloud             01:01 PM   02:30 PM   1:29       type:meeting  
-               Monitoring -                                                     
-               Weekly                                                           
-  2023-01-26   🍜 Lunch          12:35 PM   01:00 PM   0:24                     
-  2023-01-26   sync              12:06 PM   12:35 PM   0:28       type:sync     
-  2023-01-26   gather town       11:31 AM   12:06 PM   0:35       type:meeting  
-  2023-01-26   azure2: follow    10:55 AM   11:31 AM   0:35       type:goal     
-               up                                                               
-  2023-01-26   sync              08:24 AM   10:55 AM   2:31       type:sync     
-  2023-01-26   toggl-track:      07:28 AM   08:08 AM   0:39                     
-               list time                                                        
-               entries                                                          
-  2023-01-26   toggl-track:      06:48 AM   07:17 AM   0:28                     
-               list time                                                        
-               entries                                                          
-  2023-01-26   🥐 Breakfast      06:06 AM   06:48 AM   0:42                     
-  2023-01-26   toggl-track:      05:11 AM   06:06 AM   0:54                     
-               list time                                                        
-               entries                                                          
- ────────────────────────────────────────────────────────────────────────────── 
-                                            Total      16:39                    
-                                                                                
+            == """                              Time Entries                               
+                                                                         
+  At           Description        Start      Stop       Duration   Tags  
+ ─────────────────────────────────────────────────────────────────────── 
+  2024-02-26   Ristrutturazione   10:03 AM   12:07 PM   2:04             
+ ─────────────────────────────────────────────────────────────────────── 
+                                             Total      2:04             
+                                                                         
 
 """
         )
@@ -142,7 +81,12 @@ def test_list_with_a_running_time_entry(save_to_tmp):
     with runner.isolated_filesystem():
         result = runner.invoke(
             cli,
-            ["entries", "list", "--start-date", "2023-02-03", "--end-date", "2023-02-05"],
+            [
+                "entries",
+                "list",
+                "--start-date", "2024-02-03",
+                "--end-date", "2024-02-05"
+            ],
             env=env,
         )
         save_to_tmp(result.output, name="test_list_with_a_running_time_entry")
@@ -151,56 +95,29 @@ def test_list_with_a_running_time_entry(save_to_tmp):
             result.output
             == """                                  Time Entries                                  
                                                                                 
-  At           Description       Start      Stop       Duration   Tags          
+  At           Description      Start      Stop       Duration   Tags           
  ────────────────────────────────────────────────────────────────────────────── 
-  2023-02-04   toggl-track:      05:37 AM              -                        
-               insights                                                         
-  2023-02-03   Community:        08:18 PM   10:09 PM   1:51       type:support  
-               Allow parsing                                                    
-               of IPv6                                                          
-               addresses in                                                     
-               ingest pipeline                                                  
-  2023-02-03   🍲 Dinner         07:19 PM   08:18 PM   0:58                     
-  2023-02-03   sync              06:19 PM   06:55 PM   0:35       type:sync     
-  2023-02-03   🚌 Shuttling      04:46 PM   06:19 PM   1:33                     
-               kids between                                                     
-               home and                                                         
-               whatever                                                         
-  2023-02-03   App Service       04:40 PM   04:46 PM   0:06       type:goal     
-               logs                                                             
-               integration:                                                     
-               troubleshootign                                                  
-               lucianpy issues                                                  
-  2023-02-03   Community:        04:21 PM   04:40 PM   0:18       type:support  
-               Allow parsing                                                    
-               of IPv6                                                          
-               addresses in                                                     
-               ingest pipeline                                                  
-  2023-02-03   Community: Fix    03:15 PM   04:21 PM   1:05       type:support  
-               parsing error                                                    
-               client port is                                                   
-               blank and                                                        
-               adjust for                                                       
-               timeStamp                                                        
-  2023-02-03   Community:        02:37 PM   03:15 PM   0:38       type:support  
-               Azure Signin                                                     
-               Module                                                           
-               authentication…                                                  
-               Issue                                                            
-  2023-02-03   Rosanna           11:06 AM   02:37 PM   3:31                     
-  2023-02-03   Community:        09:25 AM   11:06 AM   1:41       type:support  
-               Azure Signin                                                     
-               Module                                                           
-               authentication…                                                  
-               Issue                                                            
-  2023-02-03   sync              08:37 AM   09:25 AM   0:48       type:sync     
-  2023-02-03   toggl-track:      07:06 AM   08:07 AM   1:01                     
-               insights                                                         
-  2023-02-03   🥐 Breakfast      06:08 AM   07:06 AM   0:57                     
-  2023-02-03   toggl-track:      05:51 AM   06:08 AM   0:16                     
-               insights                                                         
+  2024-02-05   How to           11:00 PM   01:09 AM   2:09       type:support…  
+               performance                                                      
+               test the                                                         
+               aws-s3 input                                                     
+               in SQS mode                                                      
+  2024-02-04   How to           09:42 PM   10:59 PM   1:17       type:support…  
+               performance                                                      
+               test the                                                         
+               aws-s3 input                                                     
+               in SQS mode                                                      
+  2024-02-04   How to           05:29 PM   07:35 PM   2:06       type:support…  
+               performance                                                      
+               test the                                                         
+               aws-s3 input                                                     
+               in SQS mode                                                      
+  2024-02-03   Learn            06:07 PM   07:50 PM   1:43                      
+               Concurrent                                                       
+               Programming                                                      
+               with Go                                                          
  ────────────────────────────────────────────────────────────────────────────── 
-                                            Total      15:24                    
+                                           Total      7:16                      
                                                                                 
 
 """
@@ -214,27 +131,26 @@ def test_list_as_ndjson(save_to_tmp):
     with runner.isolated_filesystem():
         result = runner.invoke(
             cli,
-            ["--format", "ndjson", "entries", "--project-id", "178435728", "list", "--start-date", "2023-01-26", "--end-date", "2023-01-27"],
+            [
+                "--format", "ndjson",
+                "entries",
+                "--project-id", "178435728",
+                "list",
+                "--start-date", "2024-01-26",
+                "--end-date", "2024-01-27"
+            ],
             env=env,
         )
         save_to_tmp(result.output, name="test_list_as_ndjson")
         assert result.exit_code == 0
         assert (
             result.output
-            == """{"id": 2819125097, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T22:54:33+00:00", "description": "Community: Allow parsing of IPv6 addresses in ingest pipeline", "start": "2023-01-26T22:25:35+00:00", "stop": "2023-01-26T22:54:33+00:00", "duration": 1738, "tags": ["type:support"]}
-{"id": 2819082262, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T22:25:35+00:00", "description": "Community: Fix parsing error client port is blank and adjust for timeStamp", "start": "2023-01-26T21:45:11+00:00", "stop": "2023-01-26T22:25:35+00:00", "duration": 2424, "tags": ["type:support"]}
-{"id": 2819082247, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-02-03T07:46:39+00:00", "description": "Community: Fix parsing error client port is blank and adjust for timeStamp", "start": "2023-01-26T21:45:10+00:00", "stop": "2023-01-26T21:45:11+00:00", "duration": 1, "tags": ["type:support"]}
-{"id": 2819082217, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-02-03T07:46:39+00:00", "description": "Community: Fix parsing error client port is blank and adjust for timeStamp", "start": "2023-01-26T21:45:08+00:00", "stop": "2023-01-26T21:45:10+00:00", "duration": 2, "tags": ["type:support"]}
-{"id": 2819003151, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T21:45:09+00:00", "description": "Community: Azure Signin Module authentication_processing_details Issue", "start": "2023-01-26T20:39:47+00:00", "stop": "2023-01-26T21:45:09+00:00", "duration": 3922, "tags": ["type:support"]}
-{"id": 2818714203, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T18:58:23+00:00", "description": "Community: Azure Signin Module authentication_processing_details Issue", "start": "2023-01-26T17:13:25+00:00", "stop": "2023-01-26T18:58:23+00:00", "duration": 6298, "tags": ["type:support"]}
-{"id": 2818566057, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T16:48:22+00:00", "description": "Community: Azure Signin Module authentication_processing_details Issue", "start": "2023-01-26T15:55:39+00:00", "stop": "2023-01-26T16:48:22+00:00", "duration": 3163, "tags": ["type:support"]}
-{"id": 2818549545, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T15:55:39+00:00", "description": "Drop header log line in CloudFront events", "start": "2023-01-26T15:47:14+00:00", "stop": "2023-01-26T15:55:39+00:00", "duration": 505, "tags": ["type:support"]}
-{"id": 2818461010, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T15:47:14+00:00", "description": "ElasticOnAzure: questions from Deniz Coskun", "start": "2023-01-26T15:03:41+00:00", "stop": "2023-01-26T15:47:14+00:00", "duration": 2613, "tags": ["type:support"]}
-{"id": 2818271775, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T14:30:36+00:00", "description": "Cloud Monitoring - Weekly", "start": "2023-01-26T13:01:35+00:00", "stop": "2023-01-26T14:30:36+00:00", "duration": 5341, "tags": ["type:meeting"]}
-{"id": 2818128524, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T12:35:31+00:00", "description": "sync", "start": "2023-01-26T12:06:40+00:00", "stop": "2023-01-26T12:35:31+00:00", "duration": 1731, "tags": ["type:sync"]}
-{"id": 2818075670, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T12:06:40+00:00", "description": "gather town", "start": "2023-01-26T11:31:30+00:00", "stop": "2023-01-26T12:06:40+00:00", "duration": 2110, "tags": ["type:meeting"]}
-{"id": 2818022697, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T11:31:31+00:00", "description": "azure2: follow up", "start": "2023-01-26T10:55:58+00:00", "stop": "2023-01-26T11:31:31+00:00", "duration": 2133, "tags": ["type:goal"]}
-{"id": 2817783218, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2023-01-26T10:55:58+00:00", "description": "sync", "start": "2023-01-26T08:24:19+00:00", "stop": "2023-01-26T10:55:58+00:00", "duration": 9099, "tags": ["type:sync"]}
+            == """{"id": 3297435983, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2024-01-28T08:39:01+00:00", "description": "IHAC using AWS WAF integration and expresses concern about the throughput", "start": "2024-01-26T17:26:31+00:00", "stop": "2024-01-26T18:00:35+00:00", "duration": 2044, "tags": ["type:support/question"]}
+{"id": 3297169916, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2024-01-26T16:34:41+00:00", "description": "S3 SQS ingest delay in performance with Elastic Agent #4264", "start": "2024-01-26T14:48:28+00:00", "stop": "2024-01-26T16:34:41+00:00", "duration": 6373, "tags": ["type:support/sdh"]}
+{"id": 3297063846, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2024-01-26T14:48:28+00:00", "description": "Migrate to ecs@mappings template shipped with Elasticsearch [step 3]", "start": "2024-01-26T13:50:21+00:00", "stop": "2024-01-26T14:48:28+00:00", "duration": 3487, "tags": ["type:goal"]}
+{"id": 3297055770, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2024-01-26T13:50:21+00:00", "description": "sync", "start": "2024-01-26T13:45:19+00:00", "stop": "2024-01-26T13:50:21+00:00", "duration": 302, "tags": ["type:sync"]}
+{"id": 3296620722, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2024-01-26T12:20:37+00:00", "description": "Migrate to ecs@mappings template shipped with Elasticsearch [step 3]", "start": "2024-01-26T08:44:02+00:00", "stop": "2024-01-26T12:20:37+00:00", "duration": 12995, "tags": ["type:goal"]}
+{"id": 3296545927, "workspace_id": 1815018, "user_id": 2621333, "project_id": 178435728, "task_id": null, "billable": false, "at": "2024-01-26T08:44:02+00:00", "description": "sync", "start": "2024-01-26T07:48:47+00:00", "stop": "2024-01-26T08:44:02+00:00", "duration": 3315, "tags": ["type:sync"]}
 """
         )
         

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -11,7 +11,7 @@ def test_empty_timeentrieslistresult_as_str():
     assert str(result) == "No time entries found."
 
 
-def test_empty_timeentrieslistresult_as_str(save_to_tmp):
+def test_timeentrieslistresult_as_str(save_to_tmp):
     entries = [TimeEntry(
         id=1,
         workspace_id=1,
@@ -41,7 +41,7 @@ def test_empty_timeentrieslistresult_as_str(save_to_tmp):
 """
 
 
-def test_empty_timeentrieslistresult_as_json(save_to_tmp):
+def test_timeentrieslistresult_as_json(save_to_tmp):
     entries = [TimeEntry(
         id=1,
         workspace_id=1,
@@ -64,7 +64,7 @@ def test_empty_timeentrieslistresult_as_json(save_to_tmp):
     assert json_result == """[{"id": 1, "workspace_id": 1, "user_id": 1, "project_id": 1, "task_id": null, "billable": false, "at": "2021-01-25T00:00:00", "description": "community:", "start": "2021-01-25T23:04:00", "stop": "2021-01-25T23:27:00", "duration": 1379, "tags": ["type:support"]}]"""
 
 
-def test_empty_timeentrieslistresult_as_json_with_root(save_to_tmp):
+def test_timeentrieslistresult_as_json_with_root(save_to_tmp):
     entries = [TimeEntry(
         id=1,
         workspace_id=1,

--- a/toggl_track/result.py
+++ b/toggl_track/result.py
@@ -1,6 +1,5 @@
 import io
 import json
-import datetime as dt
 from itertools import groupby
 from typing import Any, Iterator, List
 


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

When running toggl-track on Python 3.10+ all tests using vcrpy fail, while they keep running on 3.7, 3.8 and 3.9.

The new default for vcrpy is to store the request body as a string, so I decided to rewrite the cassettes.

### Change description
<!-- What does your code do? -->

- Replace all existing vcrpy cassettes with fresh data
- Pin Pydantic to < 2 to avoid a breaking change in v2 
- Pin all other dependencies to avoid drift.


### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
* [x] Changes are covered by tests.
* [x] Logging is meaningful in case of troubleshooting.
* [ ] Docs are updated (at least the `README.md`, if needed).
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.